### PR TITLE
Make default programming exercise project type configurable

### DIFF
--- a/src/main/java/de/tum/cit/ase/artemisModel/ProgrammingExercise.java
+++ b/src/main/java/de/tum/cit/ase/artemisModel/ProgrammingExercise.java
@@ -9,7 +9,7 @@ public class ProgrammingExercise extends Exercise {
     private String packageName;
     private boolean allowOfflineIde = true;
     private String programmingLanguage = "JAVA";
-    private String projectType = "PLAIN_GRADLE";
+    private String projectType;
     private boolean staticCodeAnalysisEnabled = false;
     // Required for creating course ProgrammingExercise
     private Course course;

--- a/src/main/java/de/tum/cit/ase/service/artemis/ArtemisConfiguration.java
+++ b/src/main/java/de/tum/cit/ase/service/artemis/ArtemisConfiguration.java
@@ -25,6 +25,9 @@ public class ArtemisConfiguration {
     @Value("${artemis.local.is-local}")
     private boolean localIsLocal;
 
+    @Value("${artemis.local.default-project-type}")
+    private String localDefaultProjectType;
+
     @Value("${artemis.ts1.url}")
     private String test1Url;
 
@@ -42,6 +45,9 @@ public class ArtemisConfiguration {
 
     @Value("${artemis.ts1.is-local}")
     private boolean test1IsLocal;
+
+    @Value("${artemis.ts1.default-project-type}")
+    private String test1DefaultProjectType;
 
     @Value("${artemis.ts3.url}")
     private String test3Url;
@@ -61,6 +67,9 @@ public class ArtemisConfiguration {
     @Value("${artemis.ts3.is-local}")
     private boolean test3IsLocal;
 
+    @Value("${artemis.ts3.default-project-type}")
+    private String test3DefaultProjectType;
+
     @Value("${artemis.ts7.url}")
     private String test7Url;
 
@@ -78,6 +87,9 @@ public class ArtemisConfiguration {
 
     @Value("${artemis.ts7.is-local}")
     private boolean test7IsLocal;
+
+    @Value("${artemis.ts7.default-project-type}")
+    private String test7DefaultProjectType;
 
     @Value("${artemis.ts8.url}")
     private String test8Url;
@@ -97,6 +109,9 @@ public class ArtemisConfiguration {
     @Value("${artemis.ts8.is-local}")
     private boolean test8IsLocal;
 
+    @Value("${artemis.ts8.default-project-type}")
+    private String test8DefaultProjectType;
+
     @Value("${artemis.staging.url}")
     private String stagingUrl;
 
@@ -114,6 +129,9 @@ public class ArtemisConfiguration {
 
     @Value("${artemis.staging.is-local}")
     private boolean stagingIsLocal;
+
+    @Value("${artemis.staging.default-project-type}")
+    private String stagingDefaultProjectType;
 
     @Value("${artemis.staging2.url}")
     private String staging2Url;
@@ -133,6 +151,9 @@ public class ArtemisConfiguration {
     @Value("${artemis.staging2.is-local}")
     private boolean staging2IsLocal;
 
+    @Value("${artemis.staging2.default-project-type}")
+    private String staging2DefaultProjectType;
+
     @Value("${artemis.production.url}")
     private String productionUrl;
 
@@ -150,6 +171,9 @@ public class ArtemisConfiguration {
 
     @Value("${artemis.production.is-local}")
     private boolean productionIsLocal;
+
+    @Value("${artemis.production.default-project-type}")
+    private String productionDefaultProjectType;
 
     public String getUrl(ArtemisServer server) {
         return switch (server) {
@@ -226,6 +250,19 @@ public class ArtemisConfiguration {
             case STAGING -> stagingIsLocal;
             case STAGING2 -> staging2IsLocal;
             case PRODUCTION -> productionIsLocal;
+        };
+    }
+
+    public String getDefaultProjectType(ArtemisServer server) {
+        return switch (server) {
+            case LOCAL -> localDefaultProjectType;
+            case TS1 -> test1DefaultProjectType;
+            case TS3 -> test3DefaultProjectType;
+            case TS7 -> test7DefaultProjectType;
+            case TS8 -> test8DefaultProjectType;
+            case STAGING -> stagingDefaultProjectType;
+            case STAGING2 -> staging2DefaultProjectType;
+            case PRODUCTION -> productionDefaultProjectType;
         };
     }
 }

--- a/src/main/java/de/tum/cit/ase/service/artemis/interaction/SimulatedArtemisAdmin.java
+++ b/src/main/java/de/tum/cit/ase/service/artemis/interaction/SimulatedArtemisAdmin.java
@@ -213,7 +213,7 @@ public class SimulatedArtemisAdmin extends SimulatedArtemisUser {
      * @param courseId the ID of the course to which the exam belongs
      * @param exam the exam for which to create the exercises
      */
-    public void createExamExercises(long courseId, Exam exam) {
+    public void createExamExercises(long courseId, Exam exam, String programmingExerciseProjectType) {
         if (!authenticated) {
             throw new IllegalStateException("User " + username + " is not logged in or does not have the necessary access rights.");
         }
@@ -301,6 +301,7 @@ public class SimulatedArtemisAdmin extends SimulatedArtemisUser {
         programmingExercise.setMaxPoints(1.0);
         programmingExercise.setShortName("progForBenchTemp" + exam.getId());
         programmingExercise.setPackageName("progforbenchtemp");
+        programmingExercise.setProjectType(programmingExerciseProjectType);
 
         webClient
             .post()
@@ -354,7 +355,7 @@ public class SimulatedArtemisAdmin extends SimulatedArtemisUser {
             .block();
     }
 
-    public ProgrammingExercise createCourseProgrammingExercise(Course course) {
+    public ProgrammingExercise createCourseProgrammingExercise(Course course, String programmingExerciseProjectType) {
         if (!authenticated) {
             throw new IllegalStateException("User " + username + " is not logged in or does not have the necessary access rights.");
         }
@@ -366,6 +367,7 @@ public class SimulatedArtemisAdmin extends SimulatedArtemisUser {
         programmingExercise.setMaxPoints(5.0);
         programmingExercise.setShortName("course" + course.getId() + "prog" + randomInt);
         programmingExercise.setPackageName("progForBenchTemp");
+        programmingExercise.setProjectType(programmingExerciseProjectType);
 
         return webClient
             .post()

--- a/src/main/java/de/tum/cit/ase/service/simulation/SimulationExecutionService.java
+++ b/src/main/java/de/tum/cit/ase/service/simulation/SimulationExecutionService.java
@@ -255,17 +255,13 @@ public class SimulationExecutionService {
 
             logAndSend(false, simulationRun, "Participating in exam...");
             requestStats.addAll(
-                performActionWithAll(
-                    threadCount,
-                    simulation.getNumberOfUsers(),
-                    i -> students[i].startExamParticipation(courseId, examId, programmingExerciseId)
+                performActionWithAll(threadCount, simulation.getNumberOfUsers(), i ->
+                    students[i].startExamParticipation(courseId, examId, programmingExerciseId)
                 )
             );
             requestStats.addAll(
-                performActionWithAll(
-                    threadCount,
-                    simulation.getNumberOfUsers(),
-                    i -> students[i].participateInExam(courseId, examId, simulation.getIdeType() == Simulation.IDEType.ONLINE)
+                performActionWithAll(threadCount, simulation.getNumberOfUsers(), i ->
+                    students[i].participateInExam(courseId, examId, simulation.getIdeType() == Simulation.IDEType.ONLINE)
                 )
             );
             requestStats.addAll(
@@ -413,7 +409,8 @@ public class SimulationExecutionService {
     private ProgrammingExercise createCourseProgrammingExercise(SimulatedArtemisAdmin admin, SimulationRun simulationRun, Course course) {
         logAndSend(false, simulationRun, "Creating course programming exercise...");
         try {
-            return admin.createCourseProgrammingExercise(course);
+            ArtemisServer server = simulationRun.getSimulation().getServer();
+            return admin.createCourseProgrammingExercise(course, artemisConfiguration.getDefaultProjectType(server));
         } catch (Exception e) {
             logAndSend(true, simulationRun, "Error while creating course programming exercise: %s", e.getMessage());
             failSimulationRun(simulationRun);
@@ -454,7 +451,8 @@ public class SimulationExecutionService {
     private void createExamExercises(SimulatedArtemisAdmin admin, SimulationRun simulationRun, long courseId, Exam exam) {
         logAndSend(false, simulationRun, "Creating exam exercises...");
         try {
-            admin.createExamExercises(courseId, exam);
+            ArtemisServer server = simulationRun.getSimulation().getServer();
+            admin.createExamExercises(courseId, exam, artemisConfiguration.getDefaultProjectType(server));
         } catch (Exception e) {
             logAndSend(true, simulationRun, "Error while creating exam exercises: %s", e.getMessage());
             failSimulationRun(simulationRun);

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -33,9 +33,9 @@ spring:
       indent-output: true
   datasource:
     type: com.zaxxer.hikari.HikariDataSource
-    url: jdbc:mysql://localhost:3306/artemis-benchmarking?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&createDatabaseIfNotExist=true
+    url: jdbc:mysql://localhost:3306/artemis-benchmarking?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&createDatabaseIfNotExist=true
     username: root
-    password: 12345678
+    password:
     hikari:
       poolName: Hikari
       auto-commit: false
@@ -58,7 +58,7 @@ spring:
     cache: false
 
 server:
-  port: 8080
+  port: 8081
 
 # ===================================================================
 # JHipster specific properties

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -254,6 +254,7 @@ artemis:
       artemis: artemis-test8.artemis.cit.tum.de:9100
       vcs:
       ci:
+    default-project-type: PLAIN_GRADLE
   staging:
     url: https://artemis-staging.artemis.in.tum.de/
     cleanup-enabled: false

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -218,6 +218,7 @@ artemis:
       artemis:
       vcs:
       ci:
+    default-project-type: PLAIN_GRADLE # alternatively set to PLAIN_MAVEN, MAVEN_MAVEN etc.
   ts3:
     url: https://artemis-test3.artemis.cit.tum.de/
     cleanup-enabled: false
@@ -226,6 +227,7 @@ artemis:
       artemis: artemis-test3.artemis.cit.tum.de:9100
       vcs:
       ci:
+    default-project-type: PLAIN_GRADLE
   ts1:
     url: https://artemis-test7.artemis.cit.tum.de/
     cleanup-enabled: false
@@ -234,6 +236,7 @@ artemis:
       artemis: artemis-test1.artemis.cit.tum.de:9100
       vcs: bitbucket-prelive-node1.ase.in.tum.de:9100
       ci: bamboo-prelive-instance.ase.in.tum.de:9100
+    default-project-type: PLAIN_GRADLE
   ts7:
     url: https://artemis-test7.artemis.cit.tum.de/
     cleanup-enabled: false
@@ -242,6 +245,7 @@ artemis:
       artemis: artemis-test7.artemis.cit.tum.de:9100
       vcs:
       ci:
+    default-project-type: PLAIN_GRADLE
   ts8:
     url: https://artemis-test8.artemis.cit.tum.de/
     cleanup-enabled: false
@@ -258,6 +262,7 @@ artemis:
       artemis:
       vcs: bitbucket-prelive-node1.ase.in.tum.de:9100
       ci: bamboo-prelive-instance.ase.in.tum.de:9100
+    default-project-type: PLAIN_GRADLE
   staging2:
     url: https://artemis-staging-localci.artemis.cit.tum.de/
     cleanup-enabled: false
@@ -266,6 +271,7 @@ artemis:
       artemis:
       vcs:
       ci:
+    default-project-type: PLAIN_GRADLE
   production:
     url: https://artemis.cit.tum.de/
     cleanup-enabled: false
@@ -274,7 +280,7 @@ artemis:
       artemis:
       vcs: bitbucket-node1.ase.in.tum.de:9100
       ci: bamboo-instance.ase.in.tum.de:9100
-
+    default-project-type: PLAIN_GRADLE
 prometheus:
   api-url: https://artemis-test-prometheus.artemis.cit.tum.de/
   auth-token: # Base64 encoded token for Prometheus API (Basic auth)

--- a/src/test/java/de/tum/cit/ase/service/SimulationExecutionServiceIT.java
+++ b/src/test/java/de/tum/cit/ase/service/SimulationExecutionServiceIT.java
@@ -85,6 +85,8 @@ public class SimulationExecutionServiceIT {
     private MockedStatic<SimulatedArtemisUser> mockedSimulatedArtemisUser;
     private List<SimulationRun.Status> statusesOnWebsocketUpdate;
 
+    private final String DEFAULT_PROJECT_TYPE = "PLAIN_GRADLE";
+
     @BeforeEach
     public void init() {
         simulationExecutionService.setDoNotSleep(true);
@@ -194,6 +196,7 @@ public class SimulationExecutionServiceIT {
         run.setSimulation(simulation);
 
         when(artemisConfiguration.getCleanup(TS1)).thenReturn(true);
+        when(artemisConfiguration.getDefaultProjectType(TS1)).thenReturn(DEFAULT_PROJECT_TYPE);
 
         simulationExecutionService.simulateExam(run);
 
@@ -201,7 +204,7 @@ public class SimulationExecutionServiceIT {
         verify(simulatedArtemisAdmin, times(1)).createCourse();
         verify(simulatedArtemisAdmin, times(0)).getCourse(anyLong());
         verify(simulatedArtemisAdmin, times(1)).createExam(course);
-        verify(simulatedArtemisAdmin, times(1)).createExamExercises(1, exam);
+        verify(simulatedArtemisAdmin, times(1)).createExamExercises(1, exam, DEFAULT_PROJECT_TYPE);
         verify(simulatedArtemisAdmin, times(1)).registerStudentsForCourse(
             1,
             new SimulatedArtemisStudent[] { simulatedArtemisStudent1, simulatedArtemisStudent2, simulatedArtemisStudent3 }
@@ -254,6 +257,7 @@ public class SimulationExecutionServiceIT {
         run.setStatus(QUEUED);
 
         when(artemisConfiguration.getCleanup(TS1)).thenReturn(false);
+        when(artemisConfiguration.getDefaultProjectType(TS1)).thenReturn(DEFAULT_PROJECT_TYPE);
 
         simulationExecutionService.simulateExam(run);
 
@@ -261,7 +265,7 @@ public class SimulationExecutionServiceIT {
         verify(simulatedArtemisAdmin, times(1)).createCourse();
         verify(simulatedArtemisAdmin, times(0)).getCourse(anyLong());
         verify(simulatedArtemisAdmin, times(1)).createExam(course);
-        verify(simulatedArtemisAdmin, times(1)).createExamExercises(1, exam);
+        verify(simulatedArtemisAdmin, times(1)).createExamExercises(1, exam, DEFAULT_PROJECT_TYPE);
         verify(simulatedArtemisAdmin, times(1)).registerStudentsForCourse(
             1,
             new SimulatedArtemisStudent[] { simulatedArtemisStudent1, simulatedArtemisStudent2, simulatedArtemisStudent3 }
@@ -314,6 +318,7 @@ public class SimulationExecutionServiceIT {
         run.setSimulation(simulation);
 
         when(artemisConfiguration.getCleanup(TS1)).thenReturn(true);
+        when(artemisConfiguration.getDefaultProjectType(TS1)).thenReturn(DEFAULT_PROJECT_TYPE);
 
         simulationExecutionService.simulateExam(run);
 
@@ -321,7 +326,7 @@ public class SimulationExecutionServiceIT {
         verify(simulatedArtemisAdmin, times(0)).createCourse();
         verify(simulatedArtemisAdmin, times(1)).getCourse(1);
         verify(simulatedArtemisAdmin, times(1)).createExam(course);
-        verify(simulatedArtemisAdmin, times(1)).createExamExercises(1, exam);
+        verify(simulatedArtemisAdmin, times(1)).createExamExercises(1, exam, DEFAULT_PROJECT_TYPE);
         verify(simulatedArtemisAdmin, times(0)).registerStudentsForCourse(anyLong(), any());
         verify(simulatedArtemisAdmin, times(1)).registerStudentsForExam(1, 1);
         verify(simulatedArtemisAdmin, times(1)).prepareExam(1, 1);
@@ -371,6 +376,7 @@ public class SimulationExecutionServiceIT {
         run.setSimulation(simulation);
 
         when(artemisConfiguration.getCleanup(TS1)).thenReturn(false);
+        when(artemisConfiguration.getDefaultProjectType(TS1)).thenReturn(DEFAULT_PROJECT_TYPE);
 
         simulationExecutionService.simulateExam(run);
 
@@ -378,7 +384,7 @@ public class SimulationExecutionServiceIT {
         verify(simulatedArtemisAdmin, times(0)).createCourse();
         verify(simulatedArtemisAdmin, times(1)).getCourse(1);
         verify(simulatedArtemisAdmin, times(1)).createExam(course);
-        verify(simulatedArtemisAdmin, times(1)).createExamExercises(1, exam);
+        verify(simulatedArtemisAdmin, times(1)).createExamExercises(1, exam, DEFAULT_PROJECT_TYPE);
         verify(simulatedArtemisAdmin, times(0)).registerStudentsForCourse(anyLong(), any());
         verify(simulatedArtemisAdmin, times(1)).registerStudentsForExam(1, 1);
         verify(simulatedArtemisAdmin, times(1)).prepareExam(1, 1);
@@ -429,14 +435,13 @@ public class SimulationExecutionServiceIT {
         run.setSimulation(simulation);
 
         when(artemisConfiguration.getCleanup(TS1)).thenReturn(true);
-
         simulationExecutionService.simulateExam(run);
 
         verify(simulatedArtemisAdmin, times(1)).login();
         verify(simulatedArtemisAdmin, times(0)).createCourse();
         verify(simulatedArtemisAdmin, times(1)).getCourse(1);
         verify(simulatedArtemisAdmin, times(0)).createExam(any());
-        verify(simulatedArtemisAdmin, times(0)).createExamExercises(anyLong(), any());
+        verify(simulatedArtemisAdmin, times(0)).createExamExercises(anyLong(), any(), anyString());
         verify(simulatedArtemisAdmin, times(0)).registerStudentsForCourse(anyLong(), any());
         verify(simulatedArtemisAdmin, times(0)).registerStudentsForExam(anyLong(), anyLong());
         verify(simulatedArtemisAdmin, times(1)).prepareExam(1, 1);
@@ -496,7 +501,7 @@ public class SimulationExecutionServiceIT {
         verify(simulatedArtemisAdmin, times(0)).createCourse();
         verify(simulatedArtemisAdmin, times(0)).getCourse(1);
         verify(simulatedArtemisAdmin, times(0)).createExam(any());
-        verify(simulatedArtemisAdmin, times(0)).createExamExercises(anyLong(), any());
+        verify(simulatedArtemisAdmin, times(0)).createExamExercises(anyLong(), any(), anyString());
         verify(simulatedArtemisAdmin, times(0)).registerStudentsForCourse(anyLong(), any());
         verify(simulatedArtemisAdmin, times(0)).registerStudentsForExam(anyLong(), anyLong());
         verify(simulatedArtemisAdmin, times(0)).prepareExam(1, 1);
@@ -550,6 +555,7 @@ public class SimulationExecutionServiceIT {
         run.setAdminAccount(accountDTO);
 
         when(artemisConfiguration.getCleanup(PRODUCTION)).thenReturn(true);
+        when(artemisConfiguration.getDefaultProjectType(TS1)).thenReturn(DEFAULT_PROJECT_TYPE);
 
         simulationExecutionService.simulateExam(run);
 
@@ -557,7 +563,7 @@ public class SimulationExecutionServiceIT {
         verify(simulatedArtemisAdmin, times(1)).createCourse();
         verify(simulatedArtemisAdmin, times(0)).getCourse(anyLong());
         verify(simulatedArtemisAdmin, times(1)).createExam(course);
-        verify(simulatedArtemisAdmin, times(1)).createExamExercises(1, exam);
+        verify(simulatedArtemisAdmin, times(1)).createExamExercises(1, exam, DEFAULT_PROJECT_TYPE);
         verify(simulatedArtemisAdmin, times(1)).registerStudentsForCourse(
             1,
             new SimulatedArtemisStudent[] { simulatedArtemisStudent1, simulatedArtemisStudent2, simulatedArtemisStudent3 }
@@ -618,7 +624,7 @@ public class SimulationExecutionServiceIT {
         verify(simulatedArtemisAdmin, times(0)).createCourse();
         verify(simulatedArtemisAdmin, times(0)).getCourse(anyLong());
         verify(simulatedArtemisAdmin, times(0)).createExam(any());
-        verify(simulatedArtemisAdmin, times(0)).createExamExercises(anyLong(), any());
+        verify(simulatedArtemisAdmin, times(0)).createExamExercises(anyLong(), any(), anyString());
         verify(simulatedArtemisAdmin, times(0)).registerStudentsForCourse(anyLong(), any());
         verify(simulatedArtemisAdmin, times(0)).registerStudentsForExam(anyLong(), anyLong());
         verify(simulatedArtemisAdmin, times(0)).prepareExam(anyLong(), anyLong());
@@ -673,7 +679,7 @@ public class SimulationExecutionServiceIT {
         verify(simulatedArtemisAdmin, times(0)).createCourse();
         verify(simulatedArtemisAdmin, times(0)).getCourse(anyLong());
         verify(simulatedArtemisAdmin, times(0)).createExam(any());
-        verify(simulatedArtemisAdmin, times(0)).createExamExercises(anyLong(), any());
+        verify(simulatedArtemisAdmin, times(0)).createExamExercises(anyLong(), any(), anyString());
         verify(simulatedArtemisAdmin, times(0)).registerStudentsForCourse(anyLong(), any());
         verify(simulatedArtemisAdmin, times(0)).registerStudentsForExam(anyLong(), anyLong());
         verify(simulatedArtemisAdmin, times(0)).prepareExam(anyLong(), anyLong());
@@ -730,7 +736,7 @@ public class SimulationExecutionServiceIT {
         verify(simulatedArtemisAdmin, times(1)).createCourse();
         verify(simulatedArtemisAdmin, times(0)).getCourse(anyLong());
         verify(simulatedArtemisAdmin, times(0)).createExam(any());
-        verify(simulatedArtemisAdmin, times(0)).createExamExercises(anyLong(), any());
+        verify(simulatedArtemisAdmin, times(0)).createExamExercises(anyLong(), any(), anyString());
         verify(simulatedArtemisAdmin, times(0)).registerStudentsForCourse(anyLong(), any());
         verify(simulatedArtemisAdmin, times(0)).registerStudentsForExam(anyLong(), anyLong());
         verify(simulatedArtemisAdmin, times(0)).prepareExam(anyLong(), anyLong());
@@ -787,7 +793,7 @@ public class SimulationExecutionServiceIT {
         verify(simulatedArtemisAdmin, times(1)).createCourse();
         verify(simulatedArtemisAdmin, times(0)).getCourse(anyLong());
         verify(simulatedArtemisAdmin, times(0)).createExam(any());
-        verify(simulatedArtemisAdmin, times(0)).createExamExercises(anyLong(), any());
+        verify(simulatedArtemisAdmin, times(0)).createExamExercises(anyLong(), any(), anyString());
         verify(simulatedArtemisAdmin, times(1)).registerStudentsForCourse(
             1,
             new SimulatedArtemisStudent[] { simulatedArtemisStudent1, simulatedArtemisStudent2, simulatedArtemisStudent3 }
@@ -848,7 +854,7 @@ public class SimulationExecutionServiceIT {
         verify(simulatedArtemisAdmin, times(0)).createCourse();
         verify(simulatedArtemisAdmin, times(1)).getCourse(1);
         verify(simulatedArtemisAdmin, times(0)).createExam(any());
-        verify(simulatedArtemisAdmin, times(0)).createExamExercises(anyLong(), any());
+        verify(simulatedArtemisAdmin, times(0)).createExamExercises(anyLong(), any(), anyString());
         verify(simulatedArtemisAdmin, times(0)).registerStudentsForCourse(anyLong(), any());
         verify(simulatedArtemisAdmin, times(0)).registerStudentsForExam(anyLong(), anyLong());
         verify(simulatedArtemisAdmin, times(0)).prepareExam(anyLong(), anyLong());
@@ -906,7 +912,7 @@ public class SimulationExecutionServiceIT {
         verify(simulatedArtemisAdmin, times(0)).createCourse();
         verify(simulatedArtemisAdmin, times(1)).getCourse(1);
         verify(simulatedArtemisAdmin, times(1)).createExam(course);
-        verify(simulatedArtemisAdmin, times(0)).createExamExercises(anyLong(), any());
+        verify(simulatedArtemisAdmin, times(0)).createExamExercises(anyLong(), any(), anyString());
         verify(simulatedArtemisAdmin, times(0)).registerStudentsForCourse(anyLong(), any());
         verify(simulatedArtemisAdmin, times(0)).registerStudentsForExam(anyLong(), anyLong());
         verify(simulatedArtemisAdmin, times(0)).prepareExam(anyLong(), anyLong());
@@ -956,7 +962,9 @@ public class SimulationExecutionServiceIT {
         run.setSimulation(simulation);
 
         when(artemisConfiguration.getCleanup(TS1)).thenReturn(true);
-        doThrow(new RuntimeException("Test exception")).when(simulatedArtemisAdmin).createExamExercises(anyLong(), any());
+        when(artemisConfiguration.getDefaultProjectType(TS1)).thenReturn(DEFAULT_PROJECT_TYPE);
+
+        doThrow(new RuntimeException("Test exception")).when(simulatedArtemisAdmin).createExamExercises(anyLong(), any(), anyString());
 
         assertThrows(SimulationFailedException.class, () -> simulationExecutionService.simulateExam(run));
 
@@ -964,7 +972,7 @@ public class SimulationExecutionServiceIT {
         verify(simulatedArtemisAdmin, times(0)).createCourse();
         verify(simulatedArtemisAdmin, times(1)).getCourse(1);
         verify(simulatedArtemisAdmin, times(1)).createExam(course);
-        verify(simulatedArtemisAdmin, times(1)).createExamExercises(1, exam);
+        verify(simulatedArtemisAdmin, times(1)).createExamExercises(1, exam, DEFAULT_PROJECT_TYPE);
         verify(simulatedArtemisAdmin, times(0)).registerStudentsForCourse(anyLong(), any());
         verify(simulatedArtemisAdmin, times(0)).registerStudentsForExam(anyLong(), anyLong());
         verify(simulatedArtemisAdmin, times(0)).prepareExam(anyLong(), anyLong());
@@ -1014,6 +1022,8 @@ public class SimulationExecutionServiceIT {
         run.setSimulation(simulation);
 
         when(artemisConfiguration.getCleanup(TS1)).thenReturn(true);
+        when(artemisConfiguration.getDefaultProjectType(TS1)).thenReturn(DEFAULT_PROJECT_TYPE);
+
         doThrow(new RuntimeException("Test exception")).when(simulatedArtemisAdmin).registerStudentsForExam(anyLong(), anyLong());
 
         assertThrows(SimulationFailedException.class, () -> simulationExecutionService.simulateExam(run));
@@ -1022,7 +1032,7 @@ public class SimulationExecutionServiceIT {
         verify(simulatedArtemisAdmin, times(0)).createCourse();
         verify(simulatedArtemisAdmin, times(1)).getCourse(1);
         verify(simulatedArtemisAdmin, times(1)).createExam(course);
-        verify(simulatedArtemisAdmin, times(1)).createExamExercises(1, exam);
+        verify(simulatedArtemisAdmin, times(1)).createExamExercises(1, exam, DEFAULT_PROJECT_TYPE);
         verify(simulatedArtemisAdmin, times(0)).registerStudentsForCourse(anyLong(), any());
         verify(simulatedArtemisAdmin, times(1)).registerStudentsForExam(1, 1);
         verify(simulatedArtemisAdmin, times(0)).prepareExam(anyLong(), anyLong());
@@ -1072,6 +1082,8 @@ public class SimulationExecutionServiceIT {
         run.setSimulation(simulation);
 
         when(artemisConfiguration.getCleanup(TS1)).thenReturn(true);
+        when(artemisConfiguration.getDefaultProjectType(TS1)).thenReturn(DEFAULT_PROJECT_TYPE);
+
         doThrow(new RuntimeException("Test exception")).when(simulatedArtemisAdmin).prepareExam(anyLong(), anyLong());
 
         assertThrows(SimulationFailedException.class, () -> simulationExecutionService.simulateExam(run));
@@ -1080,7 +1092,7 @@ public class SimulationExecutionServiceIT {
         verify(simulatedArtemisAdmin, times(0)).createCourse();
         verify(simulatedArtemisAdmin, times(1)).getCourse(1);
         verify(simulatedArtemisAdmin, times(1)).createExam(course);
-        verify(simulatedArtemisAdmin, times(1)).createExamExercises(1, exam);
+        verify(simulatedArtemisAdmin, times(1)).createExamExercises(1, exam, DEFAULT_PROJECT_TYPE);
         verify(simulatedArtemisAdmin, times(0)).registerStudentsForCourse(anyLong(), any());
         verify(simulatedArtemisAdmin, times(1)).registerStudentsForExam(1, 1);
         verify(simulatedArtemisAdmin, times(1)).prepareExam(1, 1);
@@ -1130,6 +1142,7 @@ public class SimulationExecutionServiceIT {
         run.setSimulation(simulation);
 
         when(artemisConfiguration.getCleanup(TS1)).thenReturn(true);
+        when(artemisConfiguration.getDefaultProjectType(TS1)).thenReturn(DEFAULT_PROJECT_TYPE);
 
         when(simulatedArtemisStudent1.login()).thenThrow(new RuntimeException("Test exception"));
         when(simulatedArtemisStudent2.login()).thenThrow(new RuntimeException("Test exception"));
@@ -1165,7 +1178,7 @@ public class SimulationExecutionServiceIT {
         verify(simulatedArtemisAdmin, times(0)).createCourse();
         verify(simulatedArtemisAdmin, times(1)).getCourse(1);
         verify(simulatedArtemisAdmin, times(1)).createExam(course);
-        verify(simulatedArtemisAdmin, times(1)).createExamExercises(1, exam);
+        verify(simulatedArtemisAdmin, times(1)).createExamExercises(1, exam, DEFAULT_PROJECT_TYPE);
         verify(simulatedArtemisAdmin, times(0)).registerStudentsForCourse(anyLong(), any());
         verify(simulatedArtemisAdmin, times(1)).registerStudentsForExam(1, 1);
         verify(simulatedArtemisAdmin, times(1)).prepareExam(1, 1);
@@ -1215,6 +1228,8 @@ public class SimulationExecutionServiceIT {
         run.setSimulation(simulation);
 
         when(artemisConfiguration.getCleanup(TS1)).thenReturn(true);
+        when(artemisConfiguration.getDefaultProjectType(TS1)).thenReturn(DEFAULT_PROJECT_TYPE);
+
         doThrow(new RuntimeException("Test exception")).when(simulatedArtemisAdmin).deleteExam(anyLong(), anyLong());
 
         simulationExecutionService.simulateExam(run);
@@ -1223,7 +1238,7 @@ public class SimulationExecutionServiceIT {
         verify(simulatedArtemisAdmin, times(0)).createCourse();
         verify(simulatedArtemisAdmin, times(1)).getCourse(1);
         verify(simulatedArtemisAdmin, times(1)).createExam(course);
-        verify(simulatedArtemisAdmin, times(1)).createExamExercises(1, exam);
+        verify(simulatedArtemisAdmin, times(1)).createExamExercises(1, exam, DEFAULT_PROJECT_TYPE);
         verify(simulatedArtemisAdmin, times(0)).registerStudentsForCourse(anyLong(), any());
         verify(simulatedArtemisAdmin, times(1)).registerStudentsForExam(1, 1);
         verify(simulatedArtemisAdmin, times(1)).prepareExam(1, 1);

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -98,6 +98,7 @@ artemis:
       artemis:
       vcs:
       ci:
+    default-project-type: PLAIN_GRADLE
   ts3:
     url:
     cleanup-enabled: false
@@ -106,6 +107,7 @@ artemis:
       artemis:
       vcs:
       ci:
+    default-project-type: PLAIN_GRADLE
   ts1:
     url:
     cleanup-enabled: false
@@ -114,6 +116,7 @@ artemis:
       artemis:
       vcs:
       ci:
+    default-project-type: PLAIN_GRADLE
   ts7:
     url:
     cleanup-enabled: false
@@ -122,6 +125,7 @@ artemis:
       artemis:
       vcs:
       ci:
+    default-project-type: PLAIN_GRADLE
   ts8:
     url:
     cleanup-enabled: false
@@ -130,6 +134,7 @@ artemis:
       artemis:
       vcs:
       ci:
+    default-project-type: PLAIN_GRADLE
   staging:
     url:
     cleanup-enabled: false
@@ -138,6 +143,7 @@ artemis:
       artemis:
       vcs:
       ci:
+    default-project-type: PLAIN_GRADLE
   staging2:
     url:
     cleanup-enabled: false
@@ -146,6 +152,7 @@ artemis:
       artemis:
       vcs:
       ci:
+    default-project-type: PLAIN_GRADLE
   production:
     url:
     cleanup-enabled: false
@@ -154,7 +161,7 @@ artemis:
       artemis:
       vcs:
       ci:
-
+    default-project-type: PLAIN_GRADLE
 prometheus:
   api-url:
   auth-token: # Base64 encoded token for Prometheus API (Basic auth)


### PR DESCRIPTION
- make default project type for programming exercises configurable (per server, e.g. artemis.local.default-project-type: PLAIN_MAVEN)
- small adjustments to local config to make running benchmarking tool + artemis locally at the same time easier