### PR TITLE
Remove explicit `standalone: true`

### DIFF
--- a/src/main/webapp/app/layouts/ci-status-card/ci-status-card.component.ts
+++ b/src/main/webapp/app/layouts/ci-status-card/ci-status-card.component.ts
@@ -7,7 +7,6 @@ import { DecimalPipe } from '@angular/common';
   imports: [DecimalPipe],
   templateUrl: './ci-status-card.component.html',
   styleUrl: './ci-status-card.component.scss',
-  standalone: true,
 })
 export class CiStatusCardComponent {
   ciStatus = input.required<CiStatus>();

--- a/src/main/webapp/app/layouts/create-simulation-box/create-simulation-box.component.ts
+++ b/src/main/webapp/app/layouts/create-simulation-box/create-simulation-box.component.ts
@@ -14,7 +14,6 @@ import { ModeExplanationComponent } from '../mode-explanation/mode-explanation.c
   templateUrl: './create-simulation-box.component.html',
   styleUrls: ['./create-simulation-box.component.scss'],
   imports: [FormsModule, RouterLink, FaIconComponent, ModeExplanationComponent],
-  standalone: true,
 })
 export class CreateSimulationBoxComponent implements OnInit {
   faEye = faEye;

--- a/src/main/webapp/app/layouts/log-box/log-box.component.ts
+++ b/src/main/webapp/app/layouts/log-box/log-box.component.ts
@@ -7,7 +7,6 @@ import { DatePipe, NgClass } from '@angular/common';
   templateUrl: './log-box.component.html',
   styleUrls: ['./log-box.component.scss'],
   imports: [NgClass, DatePipe],
-  standalone: true,
 })
 export class LogBoxComponent {
   logMessages = input<LogMessage[]>();

--- a/src/main/webapp/app/layouts/mode-explanation/mode-explanation.component.ts
+++ b/src/main/webapp/app/layouts/mode-explanation/mode-explanation.component.ts
@@ -7,7 +7,6 @@ import { NgbAlert } from '@ng-bootstrap/ng-bootstrap';
   templateUrl: './mode-explanation.component.html',
   styleUrls: ['./mode-explanation.component.scss'],
   imports: [NgbAlert],
-  standalone: true,
 })
 export class ModeExplanationComponent {
   readonly mode = input<Mode>();

--- a/src/main/webapp/app/layouts/server-badge/server-badge.component.ts
+++ b/src/main/webapp/app/layouts/server-badge/server-badge.component.ts
@@ -7,7 +7,6 @@ import { NgClass } from '@angular/common';
   templateUrl: './server-badge.component.html',
   styleUrls: ['./server-badge.component.scss'],
   imports: [NgClass],
-  standalone: true,
 })
 export class ServerBadgeComponent {
   readonly server = input<ArtemisServer>();

--- a/src/main/webapp/app/layouts/simulation-card/simulation-card.component.ts
+++ b/src/main/webapp/app/layouts/simulation-card/simulation-card.component.ts
@@ -18,7 +18,6 @@ import { FormsModule } from '@angular/forms';
   templateUrl: './simulation-card.component.html',
   styleUrls: ['./simulation-card.component.scss'],
   imports: [FaIconComponent, NgbTooltip, NgClass, ServerBadgeComponent, StatusIconComponent, DatePipe, FormsModule],
-  standalone: true,
 })
 export class SimulationCardComponent implements OnInit {
   faTrashCan = faTrashCan;

--- a/src/main/webapp/app/layouts/simulation-schedule-dialog/simulation-schedule-dialog.component.ts
+++ b/src/main/webapp/app/layouts/simulation-schedule-dialog/simulation-schedule-dialog.component.ts
@@ -31,7 +31,6 @@ import SharedModule from '../../shared/shared.module';
   ],
   templateUrl: './simulation-schedule-dialog.component.html',
   styleUrl: './simulation-schedule-dialog.component.scss',
-  standalone: true,
 })
 export class SimulationScheduleDialogComponent implements OnInit {
   emailRegex =

--- a/src/main/webapp/app/layouts/status-icon/status-icon.component.ts
+++ b/src/main/webapp/app/layouts/status-icon/status-icon.component.ts
@@ -8,7 +8,6 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
   templateUrl: './status-icon.component.html',
   styleUrls: ['./status-icon.component.scss'],
   imports: [FaIconComponent],
-  standalone: true,
 })
 export class StatusIconComponent {
   faCircleCheck = faCircleCheck;

--- a/src/main/webapp/app/simulations/simulations-overview/simulations-overview.component.ts
+++ b/src/main/webapp/app/simulations/simulations-overview/simulations-overview.component.ts
@@ -36,7 +36,6 @@ export function sortSimulations(simulations: Simulation[]): Simulation[] {
     ResultBoxComponent,
     DatePipe,
   ],
-  standalone: true,
 })
 export default class SimulationsOverviewComponent implements OnInit {
   faSpinner = faSpinner;


### PR DESCRIPTION
Removes the explicit `standalone: true`, which is implicit for all components in Angular 19 now