### PR TITLE
Add dev cluster as benchmark target

### DIFF
--- a/src/main/java/de/tum/cit/aet/service/artemis/ArtemisConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/service/artemis/ArtemisConfiguration.java
@@ -133,6 +133,24 @@ public class ArtemisConfiguration {
     @Value("${artemis.staging2.is-local}")
     private boolean staging2IsLocal;
 
+    @Value("${artemis.devcluster.url}")
+    private String devclusterUrl;
+
+    @Value("${artemis.devcluster.cleanup-enabled}")
+    private boolean devclusterCleanup;
+
+    @Value("${artemis.devcluster.prometheus-instances.artemis}")
+    private String[] devclusterPrometheusInstanceArtemis;
+
+    @Value("${artemis.devcluster.prometheus-instances.vcs}")
+    private String[] devclusterPrometheusInstanceVcs;
+
+    @Value("${artemis.devcluster.prometheus-instances.ci}")
+    private String[] devclusterPrometheusInstanceCi;
+
+    @Value("${artemis.devcluster.is-local}")
+    private boolean devclusterIsLocal;
+
     @Value("${artemis.production.url}")
     private String productionUrl;
 
@@ -166,6 +184,7 @@ public class ArtemisConfiguration {
             case TS8 -> test8Url;
             case STAGING -> stagingUrl;
             case STAGING2 -> staging2Url;
+            case DEVCLUSTER -> devclusterUrl;
             case PRODUCTION -> productionUrl;
         };
     }
@@ -185,6 +204,7 @@ public class ArtemisConfiguration {
             case TS8 -> test8Cleanup;
             case STAGING -> stagingCleanup;
             case STAGING2 -> staging2Cleanup;
+            case DEVCLUSTER -> devclusterCleanup;
             case PRODUCTION -> productionCleanup;
         };
     }
@@ -204,6 +224,7 @@ public class ArtemisConfiguration {
             case TS8 -> test8PrometheusInstanceArtemis;
             case STAGING -> stagingPrometheusInstanceArtemis;
             case STAGING2 -> staging2PrometheusInstanceArtemis;
+            case DEVCLUSTER -> devclusterPrometheusInstanceArtemis;
             case PRODUCTION -> productionPrometheusInstanceArtemis;
         };
     }
@@ -223,6 +244,7 @@ public class ArtemisConfiguration {
             case TS8 -> test8PrometheusInstanceVcs;
             case STAGING -> stagingPrometheusInstanceVcs;
             case STAGING2 -> staging2PrometheusInstanceVcs;
+            case DEVCLUSTER -> devclusterPrometheusInstanceVcs;
             case PRODUCTION -> productionPrometheusInstanceVcs;
         };
     }
@@ -242,6 +264,7 @@ public class ArtemisConfiguration {
             case TS8 -> test8PrometheusInstanceCi;
             case STAGING -> stagingPrometheusInstanceCi;
             case STAGING2 -> staging2PrometheusInstanceCi;
+            case DEVCLUSTER -> devclusterPrometheusInstanceCi;
             case PRODUCTION -> productionPrometheusInstanceCi;
         };
     }
@@ -261,6 +284,7 @@ public class ArtemisConfiguration {
             case TS8 -> test8IsLocal;
             case STAGING -> stagingIsLocal;
             case STAGING2 -> staging2IsLocal;
+            case DEVCLUSTER -> devclusterIsLocal;
             case PRODUCTION -> productionIsLocal;
         };
     }

--- a/src/main/java/de/tum/cit/aet/util/ArtemisServer.java
+++ b/src/main/java/de/tum/cit/aet/util/ArtemisServer.java
@@ -8,5 +8,6 @@ public enum ArtemisServer {
     TS8,
     STAGING,
     STAGING2,
+    DEVCLUSTER,
     PRODUCTION,
 }

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -266,6 +266,14 @@ artemis:
       artemis:
       vcs:
       ci:
+  devcluster:
+    url: https://artemis-dev-cluster.artemis.cit.tum.de/ # reachable from TUM network / via EduVPN
+    cleanup-enabled: true
+    is-local: true
+    prometheus-instances:
+      artemis:
+      vcs:
+      ci:
   production:
     url: https://artemis.cit.tum.de/
     cleanup-enabled: false

--- a/src/main/webapp/app/core/util/artemisServer.ts
+++ b/src/main/webapp/app/core/util/artemisServer.ts
@@ -6,5 +6,6 @@ export enum ArtemisServer {
   TS8 = 'TS8',
   STAGING = 'STAGING',
   STAGING2 = 'STAGING2',
+  DEVCLUSTER = 'DEVCLUSTER',
   PRODUCTION = 'PRODUCTION',
 }

--- a/src/main/webapp/app/layouts/server-badge/server-badge.component.html
+++ b/src/main/webapp/app/layouts/server-badge/server-badge.component.html
@@ -3,7 +3,7 @@
     class="badge"
     [ngClass]="{
       'bg-success': server() == ArtemisServer.LOCAL,
-      'bg-warning text-dark': server()?.startsWith('STAGING'),
+      'bg-warning text-dark': server()?.startsWith('STAGING') || server() == ArtemisServer.DEVCLUSTER,
       'bg-danger': server() == ArtemisServer.PRODUCTION,
       'bg-info': server()?.startsWith('TS'),
     }"

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -146,6 +146,14 @@ artemis:
       artemis:
       vcs:
       ci:
+  devcluster:
+    url:
+    cleanup-enabled: false
+    is-local: true
+    prometheus-instances:
+      artemis:
+      vcs:
+      ci:
   production:
     url:
     cleanup-enabled: false


### PR DESCRIPTION
Add the new [dev cluster](https://artemis-dev-cluster.artemis.cit.tum.de/) to the configuration and Artemis servers / benchmark targets to run benchmarks against it without any "hacks".

![image](https://github.com/user-attachments/assets/54d793e1-2dc9-4fe5-80ce-56b7af1fe873)


To test this locally, connection to TUM network (e.g. by using EduVPN) is required as the dev cluster is not reachable otherwise
Artemis admin and users have to be set up as usual in the benchmarking tool before running a benchmark:
![image](https://github.com/user-attachments/assets/1198236b-a7f7-43eb-96af-212c9f276898)

