### PR TITLE
Improve ci status build job run measurement

### DIFF
--- a/src/main/java/de/tum/cit/aet/domain/CiStatus.java
+++ b/src/main/java/de/tum/cit/aet/domain/CiStatus.java
@@ -21,7 +21,11 @@ public class CiStatus {
     private int totalJobs;
 
     @Column(name = "time_in_minutes")
-    private int timeInMinutes;
+    private long timeInMinutes;
+
+    @JsonIgnore
+    @Column(name = "start_time_nanos")
+    private long startTimeNanos;
 
     @Column(name = "avg_jobs_per_minute")
     private double avgJobsPerMinute;
@@ -63,11 +67,11 @@ public class CiStatus {
         this.totalJobs = totalJobs;
     }
 
-    public int getTimeInMinutes() {
+    public long getTimeInMinutes() {
         return timeInMinutes;
     }
 
-    public void setTimeInMinutes(int timeInMinutes) {
+    public void setTimeInMinutes(long timeInMinutes) {
         this.timeInMinutes = timeInMinutes;
     }
 
@@ -85,5 +89,13 @@ public class CiStatus {
 
     public void setSimulationRun(SimulationRun simulationRun) {
         this.simulationRun = simulationRun;
+    }
+
+    public long getStartTimeNanos() {
+        return startTimeNanos;
+    }
+
+    public void setStartTimeNanos(long startTimeNanos) {
+        this.startTimeNanos = startTimeNanos;
     }
 }

--- a/src/main/java/de/tum/cit/aet/repository/CiStatusRepository.java
+++ b/src/main/java/de/tum/cit/aet/repository/CiStatusRepository.java
@@ -13,4 +13,6 @@ public interface CiStatusRepository extends JpaRepository<CiStatus, Long> {
     @Transactional
     @Query(value = "delete from CiStatus status where status.isFinished = false")
     void deleteAllNotFinished();
+
+    CiStatus findBySimulationRunId(Long simulationRunId);
 }

--- a/src/main/java/de/tum/cit/aet/service/simulation/SimulationExecutionService.java
+++ b/src/main/java/de/tum/cit/aet/service/simulation/SimulationExecutionService.java
@@ -266,6 +266,11 @@ public class SimulationExecutionService {
                     students[i].startExamParticipation(courseId, examId, programmingExerciseId)
                 )
             );
+
+            // create ci status here and start measuring the total duration of build jobs since Artemis starts to process the queue directly
+            CiStatus status = ciStatusService.createCiStatus(simulationRun);
+            simulationRun.setCiStatus(status);
+
             requestStats.addAll(
                 performActionWithAll(threadCount, simulation.getNumberOfUsers(), i -> students[i].participateInExam(courseId, examId))
             );

--- a/src/main/resources/config/liquibase/changelog/00000000000021_add_ci_status_start_time.xml
+++ b/src/main/resources/config/liquibase/changelog/00000000000021_add_ci_status_start_time.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
+                        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <changeSet id="00000000000021" author="jfr2102">
+        <addColumn tableName="ci_status">
+            <column name="start_time_nanos" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <modifyDataType tableName="ci_status" columnName="time_in_minutes" newDataType="bigint" />
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -29,7 +29,7 @@
     <include file="/config/liquibase/changelog/00000000000018_add_ide_type.xml" relativeToChangelogFile="false"/>
     <include file="/config/liquibase/changelog/00000000000019_add_token_SSH_key_to_user.xml" relativeToChangelogFile="false"/>
     <include file="/config/liquibase/changelog/00000000000020_add_participation_mode_percentages.xml" relativeToChangelogFile="false"/>
-
+    <include file="/config/liquibase/changelog/00000000000021_add_ci_status_start_time.xml" relativeToChangelogFile="false"/>
     <!-- jhipster-needle-liquibase-add-changelog - JHipster will add liquibase changelogs here -->
     <!-- jhipster-needle-liquibase-add-constraints-changelog - JHipster will add liquibase constraints changelogs here -->
     <!-- jhipster-needle-liquibase-add-incremental-changelog - JHipster will add incremental liquibase changelogs here -->

--- a/src/test/java/de/tum/cit/aet/service/SimulationExecutionServiceIT.java
+++ b/src/test/java/de/tum/cit/aet/service/SimulationExecutionServiceIT.java
@@ -17,6 +17,7 @@ import de.tum.cit.aet.domain.ArtemisUser;
 import de.tum.cit.aet.domain.LogMessage;
 import de.tum.cit.aet.domain.Simulation;
 import de.tum.cit.aet.domain.SimulationRun;
+import de.tum.cit.aet.repository.CiStatusRepository;
 import de.tum.cit.aet.repository.LogMessageRepository;
 import de.tum.cit.aet.repository.SimulationRunRepository;
 import de.tum.cit.aet.service.artemis.ArtemisConfiguration;
@@ -57,6 +58,9 @@ public class SimulationExecutionServiceIT {
 
     @MockitoBean
     private SimulationRunRepository simulationRunRepository;
+
+    @MockitoBean
+    private CiStatusRepository ciStatusRepository;
 
     @MockitoBean
     private LogMessageRepository logMessageRepository;
@@ -166,6 +170,7 @@ public class SimulationExecutionServiceIT {
         when(logMessageRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
         when(simulationRunRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
         when(simulationResultService.calculateAndSaveResult(any(), any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(ciStatusRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
         statusesOnWebsocketUpdate = new LinkedList<>();
         doAnswer(invocation -> {


### PR DESCRIPTION
### Description
The current way to measure how long the build jobs of a benchmark run (simulationRun) can be very inaccurate leading to huge variation from actual time took (I had runs where it actually took more than 2x than what we measured)

Changing just incrementing the duration by 1 in each iteration to actually calculating the time between start and end.

Start is when the commits are made, since thats when build agents will start processing build jobs that are added to the queue.

End if when all the build jobs associated to the run are completed. 

### Testing
Run benchmark (locally), without enabled cleanup and check if the displayed duration in the CI Status is correct.

![image](https://github.com/user-attachments/assets/5abfd544-1c56-4e2c-b25d-035e70eb0854)
