### PR TITLE
Fix account dropdown options when logged out

### DIFF
--- a/src/main/webapp/app/layouts/navbar/navbar.component.html
+++ b/src/main/webapp/app/layouts/navbar/navbar.component.html
@@ -136,7 +136,7 @@
             }
           </a>
           <ul class="dropdown-menu" ngbDropdownMenu aria-labelledby="account-menu">
-            @if (accountRef !== null) {
+            @if (accountRef) {
               <li>
                 <a
                   class="dropdown-item"


### PR DESCRIPTION
### Changes
- fix the options in the account drop down when not logged in
### Screenshots
before:

<img width="1266" alt="image" src="https://github.com/user-attachments/assets/b6a982f9-45e7-4884-bbd2-1888166a1ee6" />

after:
<img width="1248" alt="image" src="https://github.com/user-attachments/assets/2261adc3-0940-4f95-9081-b37cbef2251c" />
