### PR TITLE
Add file upload exercise type to benchmark

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemisModel/Exercise.java
+++ b/src/main/java/de/tum/cit/aet/artemisModel/Exercise.java
@@ -15,7 +15,7 @@ import java.util.Set;
         @JsonSubTypes.Type(value = ModelingExercise.class, name = "modeling"),
         @JsonSubTypes.Type(value = QuizExercise.class, name = "quiz"),
         @JsonSubTypes.Type(value = TextExercise.class, name = "text"),
-//        @JsonSubTypes.Type(value = FileUploadExercise.class, name = "file-upload")
+        @JsonSubTypes.Type(value = FileUploadExercise.class, name = "file-upload")
 })
 // @formatter:on
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -28,6 +28,14 @@ public abstract class Exercise extends DomainObject {
 
     @JsonIgnoreProperties("exercise")
     private Set<StudentParticipation> studentParticipations = new HashSet<>();
+
+    public Exercise() {}
+
+    public Exercise(ExerciseGroup exerciseGroup, String title, Double maxPoints) {
+        this.exerciseGroup = exerciseGroup;
+        this.title = title;
+        this.maxPoints = maxPoints;
+    }
 
     public String getProblemStatement() {
         return problemStatement;

--- a/src/main/java/de/tum/cit/aet/artemisModel/ExerciseGroup.java
+++ b/src/main/java/de/tum/cit/aet/artemisModel/ExerciseGroup.java
@@ -17,6 +17,12 @@ public class ExerciseGroup extends DomainObject {
     @JsonIgnoreProperties(value = "exerciseGroup", allowSetters = true)
     private Set<Exercise> exercises = new HashSet<>();
 
+    public ExerciseGroup(String title, boolean mandatory, Exam exam) {
+        this.title = title;
+        this.mandatory = mandatory;
+        this.exam = exam;
+    }
+
     public Set<Exercise> getExercises() {
         return exercises;
     }

--- a/src/main/java/de/tum/cit/aet/artemisModel/FileUploadExercise.java
+++ b/src/main/java/de/tum/cit/aet/artemisModel/FileUploadExercise.java
@@ -1,0 +1,25 @@
+package de.tum.cit.aet.artemisModel;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class FileUploadExercise extends Exercise {
+   private String filePattern;
+
+   public FileUploadExercise() {
+      super();
+   }
+
+   public FileUploadExercise(ExerciseGroup exerciseGroup, String title, Double maxPoints, String filePattern) {
+      super(exerciseGroup, title, maxPoints);
+      this.filePattern = filePattern;
+   }
+
+    public String getFilePattern() {
+        return filePattern;
+    }
+
+    public void setFilePattern(String filePattern) {
+        this.filePattern = filePattern;
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemisModel/FileUploadSubmission.java
+++ b/src/main/java/de/tum/cit/aet/artemisModel/FileUploadSubmission.java
@@ -1,0 +1,7 @@
+package de.tum.cit.aet.artemisModel;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class FileUploadSubmission extends Submission {
+}

--- a/src/main/java/de/tum/cit/aet/artemisModel/Submission.java
+++ b/src/main/java/de/tum/cit/aet/artemisModel/Submission.java
@@ -15,7 +15,7 @@ import java.util.Set;
         @JsonSubTypes.Type(value = ModelingSubmission.class, name = "modeling"),
         @JsonSubTypes.Type(value = QuizSubmission.class, name = "quiz"),
         @JsonSubTypes.Type(value = TextSubmission.class, name = "text"),
-//        @JsonSubTypes.Type(value = FileUploadSubmission.class, name = "file-upload")
+        @JsonSubTypes.Type(value = FileUploadSubmission.class, name = "file-upload")
 })
 // @formatter:on
 @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/src/main/java/de/tum/cit/aet/service/artemis/interaction/SimulatedArtemisAdmin.java
+++ b/src/main/java/de/tum/cit/aet/service/artemis/interaction/SimulatedArtemisAdmin.java
@@ -242,8 +242,8 @@ public class SimulatedArtemisAdmin extends SimulatedArtemisUser {
         exam.setStartDate(ZonedDateTime.now().plusDays(1L));
         exam.setVisibleDate(ZonedDateTime.now());
         exam.setEndDate(ZonedDateTime.now().plusDays(1L).plusHours(2L));
-        exam.setNumberOfExercisesInExam(4);
-        exam.setExamMaxPoints(5);
+        exam.setNumberOfExercisesInExam(5);
+        exam.setExamMaxPoints(6);
         exam.setWorkingTime(2 * 60 * 60);
         exam.setCourse(course);
 
@@ -265,23 +265,8 @@ public class SimulatedArtemisAdmin extends SimulatedArtemisUser {
         if (!authenticated) {
             throw new IllegalStateException("User " + username + " is not logged in or does not have the necessary access rights.");
         }
-
-        var textExerciseGroup = new ExerciseGroup();
-        textExerciseGroup.setTitle("Text Exercise Group");
-        textExerciseGroup.setMandatory(true);
-        textExerciseGroup.setExam(exam);
-
-        textExerciseGroup = webClient
-            .post()
-            .uri(uriBuilder ->
-                uriBuilder
-                    .pathSegment("api", "exam", "courses", String.valueOf(courseId), "exams", exam.getId().toString(), "exercise-groups")
-                    .build()
-            )
-            .bodyValue(textExerciseGroup)
-            .retrieve()
-            .bodyToMono(ExerciseGroup.class)
-            .block();
+        var textExerciseGroup = new ExerciseGroup("Text Exercise Group", true, exam);
+        textExerciseGroup = postExerciseGroup(exam, textExerciseGroup);
 
         var textExercise = new TextExercise();
         textExercise.setExerciseGroup(textExerciseGroup);
@@ -296,22 +281,8 @@ public class SimulatedArtemisAdmin extends SimulatedArtemisUser {
             .toBodilessEntity()
             .block();
 
-        var modelingExerciseGroup = new ExerciseGroup();
-        modelingExerciseGroup.setTitle("Modeling Exercise Group");
-        modelingExerciseGroup.setMandatory(true);
-        modelingExerciseGroup.setExam(exam);
-
-        modelingExerciseGroup = webClient
-            .post()
-            .uri(uriBuilder ->
-                uriBuilder
-                    .pathSegment("api", "exam", "courses", String.valueOf(courseId), "exams", exam.getId().toString(), "exercise-groups")
-                    .build()
-            )
-            .bodyValue(modelingExerciseGroup)
-            .retrieve()
-            .bodyToMono(ExerciseGroup.class)
-            .block();
+        var modelingExerciseGroup = new ExerciseGroup("Modeling Exercise Group", true, exam);
+        modelingExerciseGroup = postExerciseGroup(exam, modelingExerciseGroup);
 
         var modelingExercise = new ModelingExercise();
         modelingExercise.setExerciseGroup(modelingExerciseGroup);
@@ -326,22 +297,9 @@ public class SimulatedArtemisAdmin extends SimulatedArtemisUser {
             .toBodilessEntity()
             .block();
 
-        var programmingExerciseGroup = new ExerciseGroup();
-        programmingExerciseGroup.setTitle("Programming Exercise Group");
-        programmingExerciseGroup.setMandatory(true);
-        programmingExerciseGroup.setExam(exam);
+        var programmingExerciseGroup = new ExerciseGroup("Programming Exercise Group", true, exam);
 
-        programmingExerciseGroup = webClient
-            .post()
-            .uri(uriBuilder ->
-                uriBuilder
-                    .pathSegment("api", "exam", "courses", String.valueOf(courseId), "exams", exam.getId().toString(), "exercise-groups")
-                    .build()
-            )
-            .bodyValue(programmingExerciseGroup)
-            .retrieve()
-            .bodyToMono(ExerciseGroup.class)
-            .block();
+        programmingExerciseGroup = postExerciseGroup(exam, programmingExerciseGroup);
 
         var programmingExercise = new ProgrammingExercise();
         programmingExercise.setExerciseGroup(programmingExerciseGroup);
@@ -358,22 +316,9 @@ public class SimulatedArtemisAdmin extends SimulatedArtemisUser {
             .toBodilessEntity()
             .block();
 
-        var quizExerciseGroup = new ExerciseGroup();
-        quizExerciseGroup.setTitle("Quiz Exercise Group");
-        quizExerciseGroup.setMandatory(true);
-        quizExerciseGroup.setExam(exam);
+        var quizExerciseGroup = new ExerciseGroup("Quiz Exercise Group", true, exam);
 
-        quizExerciseGroup = webClient
-            .post()
-            .uri(uriBuilder ->
-                uriBuilder
-                    .pathSegment("api", "exam", "courses", String.valueOf(courseId), "exams", exam.getId().toString(), "exercise-groups")
-                    .build()
-            )
-            .bodyValue(quizExerciseGroup)
-            .retrieve()
-            .bodyToMono(ExerciseGroup.class)
-            .block();
+        quizExerciseGroup = postExerciseGroup(exam, quizExerciseGroup);
 
         var quizExercise = new QuizExercise();
         quizExercise.setExerciseGroup(quizExerciseGroup);
@@ -400,6 +345,39 @@ public class SimulatedArtemisAdmin extends SimulatedArtemisUser {
             .retrieve()
             .toBodilessEntity()
             .block();
+
+        var fileUploadExerciseGroup = new ExerciseGroup("File Upload Exercise Group", true, exam);
+        fileUploadExerciseGroup = postExerciseGroup(exam, fileUploadExerciseGroup);
+
+        var fileUploadExercise = new FileUploadExercise(fileUploadExerciseGroup,"File Upload Exercise",1.0, "pdf,txt" );
+        webClient
+            .post()
+            .uri(uriBuilder -> uriBuilder.pathSegment("api", "fileupload", "file-upload-exercises").build())
+            .bodyValue(fileUploadExercise)
+            .retrieve()
+            .toBodilessEntity()
+            .block();
+    }
+
+    /**
+     * Post an exercise group to the exam.
+     * @param exam the exam to which the exercise group belongs
+     * @param exerciseGroup the exercise group to post
+     * @return the created exercise group
+     */
+    private ExerciseGroup postExerciseGroup(Exam exam, ExerciseGroup exerciseGroup) {
+        exerciseGroup = webClient
+            .post()
+            .uri(uriBuilder ->
+                uriBuilder
+                    .pathSegment("api", "exam", "courses", String.valueOf(exam.getCourse().getId()), "exams", exam.getId().toString(), "exercise-groups")
+                    .build()
+            )
+            .bodyValue(exerciseGroup)
+            .retrieve()
+            .bodyToMono(ExerciseGroup.class)
+            .block();
+        return exerciseGroup;
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/service/artemis/interaction/SimulatedArtemisStudent.java
+++ b/src/main/java/de/tum/cit/aet/service/artemis/interaction/SimulatedArtemisStudent.java
@@ -603,7 +603,8 @@ private List<RequestStat> solveAndSubmitFileUploadExercise(FileUploadExercise fi
         .block();
     requestStats.add(new RequestStat(now(), System.nanoTime() - start, MISC));
 
-    ByteArrayResource file = FileGeneratorUtil.getDummyFile(1024 * 1024, "test-file.txt");
+    int fileSizeInBytes = 1024 * 1024; // 1 MB file size for file upload exercise
+    ByteArrayResource file = FileGeneratorUtil.getDummyFile(fileSizeInBytes, "test-file.txt");
     MultiValueMap<String, Object> multipartBody = new LinkedMultiValueMap<>();
     multipartBody.add("file", file);
     multipartBody.add("submission", new FileUploadSubmission());

--- a/src/main/java/de/tum/cit/aet/util/FileGeneratorUtil.java
+++ b/src/main/java/de/tum/cit/aet/util/FileGeneratorUtil.java
@@ -1,0 +1,36 @@
+package de.tum.cit.aet.util;
+
+import org.springframework.core.io.ByteArrayResource;
+
+import java.util.Arrays;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class FileGeneratorUtil {
+
+    private static final Map<Integer, byte[]> contentCache = new ConcurrentHashMap<>();
+
+    /**
+     * Returns a cached dummy file of a given size filled with 'A'.
+     * If not cached yet, generates and stores it.
+     *
+     * @param sizeInBytes File size in bytes.
+     * @param filename    File name.
+     * @return ByteArrayResource representing the file.
+     */
+    public static ByteArrayResource getDummyFile(int sizeInBytes, String filename) {
+        byte[] content = contentCache.computeIfAbsent(sizeInBytes, size -> {
+            byte[] data = new byte[size];
+            Arrays.fill(data, (byte) 'A');
+            return data;
+        });
+
+        return new ByteArrayResource(content) {
+            @Override
+            public String getFilename() {
+                return filename;
+            }
+        };
+    }
+}


### PR DESCRIPTION
### Description
- Adding the file upload exercise type to the exam benchmark
- simulating that each user submits 1 file 
- file is a textfile and cached in memory, so each student will submit the same content of fixed size (currently 1 MB file)

### Testing steps
- start a benchmark and check no logs occur, and that metrics e.g. for submitting exercises are present.