### PR TITLE
`Bugfix` generate new keypair when null for old users

### DIFF
--- a/src/main/java/de/tum/cit/aet/service/artemis/ArtemisUserService.java
+++ b/src/main/java/de/tum/cit/aet/service/artemis/ArtemisUserService.java
@@ -358,6 +358,7 @@ public class ArtemisUserService {
      * Generates a new SSH key pair for the given ArtemisUser.
      *
      * @param artemisUser the ArtemisUser to generate the key pair for
+     * @return the ArtemisUser with the generated key pair
      */
     public ArtemisUser generateKeyPair(ArtemisUser artemisUser) {
         artemisUser.setKeyPair(SshUtils.generateSshKeyPair());

--- a/src/main/java/de/tum/cit/aet/service/artemis/ArtemisUserService.java
+++ b/src/main/java/de/tum/cit/aet/service/artemis/ArtemisUserService.java
@@ -353,4 +353,14 @@ public class ArtemisUserService {
 
         return n + 1;
     }
+
+    /**
+     * Generates a new SSH key pair for the given ArtemisUser.
+     *
+     * @param artemisUser the ArtemisUser to generate the key pair for
+     */
+    public ArtemisUser generateKeyPair(ArtemisUser artemisUser) {
+        artemisUser.setKeyPair(SshUtils.generateSshKeyPair());
+        return artemisUserRepository.save(artemisUser);
+    }
 }

--- a/src/main/java/de/tum/cit/aet/service/artemis/interaction/SimulatedArtemisStudent.java
+++ b/src/main/java/de/tum/cit/aet/service/artemis/interaction/SimulatedArtemisStudent.java
@@ -79,7 +79,7 @@ public class SimulatedArtemisStudent extends SimulatedArtemisUser {
         this.numberOfCommitsAndPushesTo = numberOfCommitsAndPushesTo;
         this.authenticationMechanism = authMechanism;
         // for old users in the DB which might never gotten a key pair generated
-        if (artemisUser.getPublicKey()== null || artemisUser.getPrivateKey() == null) {
+        if (artemisUser.getPublicKey() == null || artemisUser.getPrivateKey() == null) {
             var savedUser = artemisUserService.generateKeyPair(artemisUser);
             this.publicKeyString = savedUser.getPublicKey();
             this.privateKeyString = savedUser.getPrivateKey();

--- a/src/main/java/de/tum/cit/aet/service/artemis/interaction/SimulatedArtemisStudent.java
+++ b/src/main/java/de/tum/cit/aet/service/artemis/interaction/SimulatedArtemisStudent.java
@@ -78,8 +78,15 @@ public class SimulatedArtemisStudent extends SimulatedArtemisUser {
         this.numberOfCommitsAndPushesFrom = numberOfCommitsAndPushesFrom;
         this.numberOfCommitsAndPushesTo = numberOfCommitsAndPushesTo;
         this.authenticationMechanism = authMechanism;
-        this.publicKeyString = artemisUser.getPublicKey();
-        this.privateKeyString = artemisUser.getPrivateKey();
+        // for old users in the DB which might never gotten a key pair generated
+        if (artemisUser.getPublicKey()== null || artemisUser.getPrivateKey() == null) {
+            var savedUser = artemisUserService.generateKeyPair(artemisUser);
+            this.publicKeyString = savedUser.getPublicKey();
+            this.privateKeyString = savedUser.getPrivateKey();
+        } else {
+            this.publicKeyString = artemisUser.getPublicKey();
+            this.privateKeyString = artemisUser.getPrivateKey();
+        }
     }
 
     @Override


### PR DESCRIPTION
### Description
on prod there are issues with users that got created before the addition of ssh key pairs which are generated when users are created.

Fixing by generating a new key when the user has null public or private key at initialization of `ArtemisSimulatedStudent`