### PR TITLE
Fix reactiveness when starting a new benchmark run

### DIFF
--- a/src/main/webapp/app/layouts/simulation-card/simulation-card.component.html
+++ b/src/main/webapp/app/layouts/simulation-card/simulation-card.component.html
@@ -7,7 +7,7 @@
         class="btn btn-link btn-sm me-3"
         (click)="openScheduleDialog()"
         ngbTooltip="Schedule"
-        [disabled]="credentialsRequired"
+        [disabled]="credentialsRequired()"
       >
         <fa-icon [icon]="faCalendarDays" class="text-info"></fa-icon>
       </button>
@@ -25,7 +25,7 @@
   <div class="card-body pt-2 pb-3 position-relative">
     <div class="space-between-wrapper">
       <div class="me-3 w-60">
-        @if (numberOfActiveSchedules > 0) {
+        @if (numberOfActiveSchedules() > 0) {
           <div
             class="alert alert-warning p-1 w-fit-content"
             role="button"
@@ -34,7 +34,9 @@
             tabindex="0"
           >
             <fa-icon class="ms-2" [icon]="faClock"></fa-icon>
-            <span class="ms-2 me-2"> {{ numberOfActiveSchedules }} {{ numberOfActiveSchedules === 1 ? 'Schedule' : 'Schedules' }} </span>
+            <span class="ms-2 me-2">
+              {{ numberOfActiveSchedules() }} {{ numberOfActiveSchedules() === 1 ? 'Schedule' : 'Schedules' }}
+            </span>
           </div>
         }
         <p>
@@ -58,11 +60,11 @@
               <button
                 type="button"
                 class="btn btn-sm btn-link p-0 h-fit-content ms-2"
-                [ngClass]="instructorAccountAvailable ? 'text-success' : 'text-danger'"
+                [ngClass]="instructorAccountAvailable() ? 'text-success' : 'text-danger'"
                 (click)="patchInstructorAccount(instructorUpdateModal)"
                 [disabled]="hasActiveRun()"
                 [ngbTooltip]="
-                  instructorAccountAvailable
+                  instructorAccountAvailable()
                     ? 'Instructor account available. Click here to update it.'
                     : 'No Instructor account available. Click here to add one.'
                 "
@@ -81,7 +83,7 @@
     </div>
   </div>
   <div class="card-footer">
-    @for (run of displayedRuns; track run) {
+    @for (run of displayedRuns(); track run) {
       <button
         type="button"
         class="shadow btn btn-outline-secondary w-100 mb-2"
@@ -100,10 +102,10 @@
   </div>
   @if (simulation().runs.length > 3) {
     <div class="card-footer">
-      @if (numberOfDisplayedRuns < simulation().runs.length) {
+      @if (numberOfDisplayedRuns() < simulation().runs.length) {
         <button type="button" class="btn btn-secondary btn-sm" (click)="increaseNumberOfDisplayedRuns()">Show more</button>
       }
-      @if (numberOfDisplayedRuns > 3) {
+      @if (numberOfDisplayedRuns() > 3) {
         <button type="button" class="btn btn-secondary btn-sm" (click)="decreaseNumberOfDisplayedRuns()">Show less</button>
       }
     </div>
@@ -129,7 +131,7 @@
         {{ simulation().courseId }}.
       </p>
     }
-    @if (credentialsRequired) {
+    @if (credentialsRequired()) {
       <form>
         <div class="mb-3">
           <label for="adminUsername" class="form-label">Username</label>
@@ -172,7 +174,7 @@
     <button
       type="submit"
       class="btn btn-primary"
-      [disabled]="(adminPassword.length === 0 || adminUsername.length === 0) && credentialsRequired"
+      [disabled]="(adminPassword.length === 0 || adminUsername.length === 0) && credentialsRequired()"
       (click)="modal.close()"
     >
       Start run
@@ -210,7 +212,7 @@
       {{ simulation().courseId }}. <span class="text-warning">The credentials will be stored in the database!</span>
     </p>
     <p>If you only want to run this simulation manually, this step is not necessary. For scheduled runs, the credentials are required.</p>
-    @if (instructorAccountAvailable) {
+    @if (instructorAccountAvailable()) {
       <p class="text-warning">Note: An Instructor account already exists for this simulation. You can override it here.</p>
     }
     <div class="mb-3">
@@ -240,7 +242,7 @@
   <div class="modal-footer space-between-wrapper">
     <div>
       <button type="reset" class="btn btn-secondary" (click)="modal.dismiss()">Cancel</button>
-      @if (instructorAccountAvailable) {
+      @if (instructorAccountAvailable()) {
         <button
           type="button"
           class="btn btn-danger"

--- a/src/main/webapp/app/layouts/simulation-card/simulation-card.component.ts
+++ b/src/main/webapp/app/layouts/simulation-card/simulation-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, inject, input, output } from '@angular/core';
+import { Component, OnInit, inject, input, output, signal, computed } from '@angular/core';
 import { getTextRepresentation, instructorCredentialsProvided, Mode, Simulation } from '../../entities/simulation/simulation';
 import { SimulationRun, Status } from '../../entities/simulation/simulationRun';
 import { SimulationsService } from '../../simulations/simulations.service';
@@ -30,19 +30,23 @@ export class SimulationCardComponent implements OnInit {
 
   simulation = input.required<Simulation>();
   selectedRun = input<SimulationRun>();
-  displayedRuns: SimulationRun[] = [];
-  numberOfDisplayedRuns = 3;
-  numberOfActiveSchedules = 0;
-  credentialsRequired = false;
-  instructorAccountAvailable = false;
+
+  runs = signal<SimulationRun[]>([]);
+  numberOfDisplayedRuns = signal(3);
+  numberOfActiveSchedules = signal(0);
+  credentialsRequired = signal(false);
+  instructorAccountAvailable = signal(false);
+
+  displayedRuns = computed(() => this.runs().slice(0, this.numberOfDisplayedRuns()));
+
+  hasActiveRun = computed(() => this.runs().some(run => run.status === Status.RUNNING));
 
   adminPassword = '';
   adminUsername = '';
   showAdminPassword = false;
 
-  readonly clickedRunEvent = output<SimulationRun>();
-  readonly delete = output();
-
+  protected readonly clickedRunEvent = output<SimulationRun>();
+  protected readonly delete = output();
   protected readonly Mode = Mode;
   protected readonly Status = Status;
   protected readonly getTextRepresentation = getTextRepresentation;
@@ -53,14 +57,15 @@ export class SimulationCardComponent implements OnInit {
   private modalService = inject(NgbModal);
 
   ngOnInit(): void {
+    this.runs.set([...this.simulation().runs]);
     this.sortRuns();
-    this.updateDisplayRuns();
-    this.simulationService.getSimulationSchedules(this.simulation().id!).subscribe(numberOfActiveSchedules => {
-      this.numberOfActiveSchedules = numberOfActiveSchedules.length;
+
+    this.simulationService.getSimulationSchedules(this.simulation().id!).subscribe(schedules => {
+      this.numberOfActiveSchedules.set(schedules.length);
     });
     this.subscribeToNewSimulationRun();
     this.updateCredentialsRequired();
-    this.instructorAccountAvailable = instructorCredentialsProvided(this.simulation());
+    this.instructorAccountAvailable.set(instructorCredentialsProvided(this.simulation()));
   }
 
   startRun(content: any): void {
@@ -69,11 +74,10 @@ export class SimulationCardComponent implements OnInit {
       this.modalService.open(content, { ariaLabelledBy: 'account-modal-title' }).result.then(
         () => {
           let account = undefined;
-          const simulationValue = this.simulation();
-          if (simulationValue.mode !== Mode.EXISTING_COURSE_PREPARED_EXAM) {
+          if (simulation.mode !== Mode.EXISTING_COURSE_PREPARED_EXAM) {
             account = new ArtemisAccountDTO(this.adminUsername, this.adminPassword);
           }
-          this.simulationService.runSimulation(simulationValue.id!, account).subscribe(newRun => {
+          this.simulationService.runSimulation(simulation.id!, account).subscribe(newRun => {
             this.addNewRun(newRun);
           });
           this.adminPassword = '';
@@ -91,6 +95,69 @@ export class SimulationCardComponent implements OnInit {
         this.addNewRun(newRun);
       });
     }
+  }
+
+  sortRuns(): void {
+    this.runs.update(runs => [...runs].sort((a, b) => new Date(b.startDateTime).getTime() - new Date(a.startDateTime).getTime()));
+  }
+
+  increaseNumberOfDisplayedRuns(): void {
+    this.numberOfDisplayedRuns.update(n => n + 3);
+  }
+
+  decreaseNumberOfDisplayedRuns(): void {
+    this.numberOfDisplayedRuns.update(n => Math.max(3, n - 3));
+  }
+
+  clickedRun(run: SimulationRun): void {
+    this.clickedRunEvent.emit(run);
+  }
+
+  deleteSimulation(content: any): void {
+    this.modalService.open(content, { ariaLabelledBy: 'delete-modal-title' }).result.then(() => {
+      this.delete.emit();
+    });
+  }
+
+  openScheduleDialog(): void {
+    const simulation = this.simulation();
+    const modalRef = this.modalService.open(SimulationScheduleDialogComponent, { size: 'xl' });
+    modalRef.componentInstance.simulation.set(simulation);
+    modalRef.hidden.subscribe(() => {
+      this.simulationService.getSimulationSchedules(simulation.id!).subscribe(schedules => {
+        this.numberOfActiveSchedules.set(schedules.length);
+      });
+    });
+  }
+
+  subscribeToNewSimulationRun(): void {
+    this.simulationService.receiveNewSimulationRun(this.simulation()).subscribe(newRun => {
+      this.addNewRun(newRun);
+    });
+  }
+
+  addNewRun(newRun: SimulationRun): void {
+    if (this.runs().some(run => run.id === newRun.id)) {
+      return;
+    }
+
+    this.runs.update(runs => [...runs, newRun]);
+    const simulation = this.simulation();
+    simulation.runs.push(newRun);
+
+    this.simulationService.receiveSimulationStatus(newRun).subscribe(status => {
+      this.runs.update(runs =>
+        runs.map(run => {
+          if (run.id === newRun.id) {
+            run.status = status;
+          }
+          return run;
+        }),
+      );
+      newRun.status = status;
+    });
+
+    this.sortRuns();
   }
 
   patchInstructorAccount(content: any): void {
@@ -113,81 +180,13 @@ export class SimulationCardComponent implements OnInit {
     );
   }
 
-  sortRuns(): void {
-    this.simulation().runs.sort((a, b) => new Date(b.startDateTime).getTime() - new Date(a.startDateTime).getTime());
-    this.displayedRuns = this.simulation().runs.slice(0, 3);
-  }
-
-  updateDisplayRuns(): void {
-    this.displayedRuns = this.simulation().runs.slice(0, this.numberOfDisplayedRuns);
-  }
-
-  increaseNumberOfDisplayedRuns(): void {
-    this.numberOfDisplayedRuns += 3;
-    this.updateDisplayRuns();
-  }
-
-  decreaseNumberOfDisplayedRuns(): void {
-    this.numberOfDisplayedRuns -= 3;
-    if (this.numberOfDisplayedRuns < 3) {
-      this.numberOfDisplayedRuns = 3;
-    }
-    this.updateDisplayRuns();
-  }
-
-  clickedRun(run: SimulationRun): void {
-    this.clickedRunEvent.emit(run);
-  }
-
-  deleteSimulation(content: any): void {
-    this.modalService.open(content, { ariaLabelledBy: 'delete-modal-title' }).result.then(() => {
-      this.delete.emit();
-    });
-  }
-
-  hasActiveRun(): boolean {
-    return this.simulation().runs.some(run => run.status === Status.RUNNING);
-  }
-
-  openScheduleDialog(): void {
-    const simulation = this.simulation();
-    const modalRef = this.modalService.open(SimulationScheduleDialogComponent, { size: 'xl' });
-    modalRef.componentInstance.simulation.set(simulation);
-    modalRef.hidden.subscribe(() => {
-      this.simulationService.getSimulationSchedules(simulation.id!).subscribe(schedules => {
-        this.numberOfActiveSchedules = schedules.length;
-      });
-    });
-  }
-
-  subscribeToNewSimulationRun(): void {
-    this.simulationService.receiveNewSimulationRun(this.simulation()).subscribe(newRun => {
-      this.addNewRun(newRun);
-    });
-  }
-
-  addNewRun(newRun: SimulationRun): void {
-    const simulation = this.simulation();
-    if (simulation.runs.some(run => run.id === newRun.id)) {
-      return;
-    }
-    simulation.runs.push(newRun);
-
-    this.simulationService.receiveSimulationStatus(newRun).subscribe(status => {
-      newRun.status = status;
-    });
-
-    this.sortRuns();
-    this.updateDisplayRuns();
-  }
-
   patchSimulationInstructorAccount(): void {
     const account = new ArtemisAccountDTO(this.adminUsername, this.adminPassword);
     this.simulationService.patchSimulationInstructorAccount(this.simulation().id!, account).subscribe(updatedSimulation => {
       const simulation = this.simulation();
       simulation.instructorUsername = updatedSimulation.instructorUsername;
       simulation.instructorPassword = updatedSimulation.instructorPassword;
-      this.instructorAccountAvailable = instructorCredentialsProvided(simulation);
+      this.instructorAccountAvailable.set(instructorCredentialsProvided(simulation));
       this.updateCredentialsRequired();
     });
   }
@@ -197,16 +196,17 @@ export class SimulationCardComponent implements OnInit {
       const simulation = this.simulation();
       simulation.instructorUsername = updatedSimulation.instructorUsername;
       simulation.instructorPassword = updatedSimulation.instructorPassword;
-      this.instructorAccountAvailable = instructorCredentialsProvided(simulation);
+      this.instructorAccountAvailable.set(instructorCredentialsProvided(simulation));
       this.updateCredentialsRequired();
     });
   }
 
   updateCredentialsRequired(): void {
     const simulation = this.simulation();
-    this.credentialsRequired =
+    this.credentialsRequired.set(
       simulation.server === ArtemisServer.PRODUCTION &&
-      simulation.mode !== Mode.EXISTING_COURSE_PREPARED_EXAM &&
-      !instructorCredentialsProvided(simulation);
+        simulation.mode !== Mode.EXISTING_COURSE_PREPARED_EXAM &&
+        !instructorCredentialsProvided(simulation),
+    );
   }
 }


### PR DESCRIPTION
### Description
When starting a new benchmark run the UI did not update unless refreshing the page.

### Testing 
Start a new benchmark run and check that the UI immediately displays the new run