### PR TITLE
Update server dependencies to latest non-breaking versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -203,14 +203,14 @@ dependencies {
     implementation "org.springframework.security:spring-security-data"
 
     // use newest version of nimbus-jose-jwt to avoid security issues through outdated dependencies
-    implementation "com.nimbusds:nimbus-jose-jwt:10.9"
+    implementation "com.nimbusds:nimbus-jose-jwt:10.9.1"
 
 
     implementation "io.micrometer:micrometer-registry-prometheus"
     // Prometheus requires the protobuf-java dependency, but we explicitly use the latest version to avoid security vulnerabilities
-    implementation "com.google.protobuf:protobuf-java:4.34.1"
+    implementation "com.google.protobuf:protobuf-java:4.35.1"
 
-    implementation "io.dropwizard.metrics:metrics-core:4.2.38"
+    implementation "io.dropwizard.metrics:metrics-core:4.2.39"
     implementation "org.springframework.security:spring-security-messaging"
     implementation "commons-io:commons-io:2.22.0"
     implementation "com.thedeanda:lorem:2.2"
@@ -248,7 +248,7 @@ dependencies {
 
     // use newest version of plexus to avoid security issues through outdated dependencies
     checkstyle "org.codehaus.plexus:plexus-container-default:2.1.1"
-    checkstyle "org.codehaus.plexus:plexus-classworlds:2.9.0"
+    checkstyle "org.codehaus.plexus:plexus-classworlds:2.12.0"
     checkstyle "com.puppycrawl.tools:checkstyle:${checkstyleVersion}"
     checkstyle "org.apache.commons:commons-lang3:${commonsLangVersion}"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,27 +6,27 @@ node_version=24.15.0
 pnpm_version=11.1.2
 
 # Dependency versions
-springBootVersion=4.0.6
+springBootVersion=4.1.0
 commonsLangVersion=3.20.0
 mapstructVersion=1.6.3
 archunitJunit5Version=1.4.2
-junitVersion=6.0.3
+junitVersion=6.1.0
 jacksonDatabindNullableVersion=0.2.10
 mysqlVersion=9.7.0
 testcontainersVersion=2.0.5
-jgitVersion=7.6.0.202603022253-r
-sshdVersion=2.17.1
+jgitVersion=7.7.0.202606012155-r
+sshdVersion=2.18.0
 
-jaxbRuntimeVersion=4.0.8
+jaxbRuntimeVersion=4.0.9
 
 # gradle plugin version
 jibPluginVersion=3.5.3
 gitPropertiesPluginVersion=2.5.7
 gradleNodePluginVersion=7.1.0
-sonarqubePluginVersion=7.3.0.8198
-spotlessPluginVersion=8.5.0
-openapiPluginVersion=7.22.0
-checkstyleVersion=13.4.2
+sonarqubePluginVersion=7.3.1.8318
+spotlessPluginVersion=8.7.0
+openapiPluginVersion=7.23.0
+checkstyleVersion=13.6.0
 modernizerPluginVersion=1.13.0
 
 liquibaseTaskPrefix=liquibase


### PR DESCRIPTION
## Summary

Updates server (Gradle) dependencies and plugins to the latest version **within their current major** (non-breaking). Discovered via `./gradlew dependencyUpdates -Drevision=release` and verified locally.

### Updated (`gradle.properties`)
| Dependency / Plugin | From | To |
| --- | --- | --- |
| Spring Boot | 4.0.6 | 4.1.0 |
| JUnit | 6.0.3 | 6.1.0 |
| JGit | 7.6.0 | 7.7.0 |
| Apache SSHD | 2.17.1 | 2.18.0 |
| JAXB runtime | 4.0.8 | 4.0.9 |
| Spotless plugin | 8.5.0 | 8.7.0 |
| SonarQube plugin | 7.3.0.8198 | 7.3.1.8318 |
| OpenAPI Generator plugin | 7.22.0 | 7.23.0 |
| Checkstyle | 13.4.2 | 13.6.0 |

### Updated (`build.gradle`)
| Dependency | From | To |
| --- | --- | --- |
| protobuf-java | 4.34.1 | 4.35.1 |
| nimbus-jose-jwt | 10.9 | 10.9.1 |
| dropwizard metrics-core | 4.2.38 | 4.2.39 |
| plexus-classworlds (checkstyle) | 2.9.0 | 2.12.0 |

Bumping Spring Boot to 4.1.0 also advances BOM-managed transitives: Hibernate 7.2→7.4, Spring Security 7.0→7.1, Micrometer 1.16→1.17, Reactor Netty 1.3.5→1.3.6, Mockito 5.20→5.23.

### Intentionally held back
- **`com.github.andygoossens.gradle-modernizer-plugin` 1.13.0 → 1.14.0:** the new version reports 30 new modernizer violations against existing code, so it is breaking in practice and would require source changes. Kept at 1.13.0.
- **`gradle-git-properties` plugin 2.5.7 → 4.0.1:** major version bump (breaking).

## Testing
- `./gradlew compileJava compileTestJava -x webapp` ✅
- `./gradlew spotlessCheck modernizer -x webapp` ✅
- `./gradlew test -x webapp` ✅ (29 tests, 0 failures)
- Note: `checkstyleMain` has pre-existing `MissingJavadocMethod` findings locally that also occur on a clean `develop` checkout (a local JDK/Checkstyle parsing difference, unrelated to this change); the Checkstyle bump itself adds **no** new violations. Integration tests (`*IT.java`) are excluded by default and run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)