### PR TITLE
Fix checkstyleMain: add missing Javadoc on public methods

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemisModel/CourseCreateDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemisModel/CourseCreateDTO.java
@@ -42,6 +42,13 @@ public record CourseCreateDTO(
     String timeZone,
     String courseInformationSharingConfiguration
 ) {
+    /**
+     * Create a course DTO pre-filled with default benchmarking values.
+     *
+     * @param title     the title of the course.
+     * @param shortName the short name of the course.
+     * @return a new {@link CourseCreateDTO} for benchmarking.
+     */
     public static CourseCreateDTO forBenchmarking(String title, String shortName) {
         return new CourseCreateDTO(
             title,

--- a/src/main/java/de/tum/cit/aet/artemisModel/ExamUpdateDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemisModel/ExamUpdateDTO.java
@@ -31,6 +31,12 @@ public record ExamUpdateDTO(
     CourseRef course,
     String examArchivePath
 ) {
+    /**
+     * Create an exam update DTO populated from the given exam entity.
+     *
+     * @param exam the exam to convert.
+     * @return a new {@link ExamUpdateDTO} populated from the given exam.
+     */
     public static ExamUpdateDTO fromExam(Exam exam) {
         Course course = exam.getCourse();
         CourseRef courseRef = course == null ? null : new CourseRef(course.getId());

--- a/src/main/java/de/tum/cit/aet/artemisModel/FileUploadExerciseCreateDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemisModel/FileUploadExerciseCreateDTO.java
@@ -12,6 +12,14 @@ public record FileUploadExerciseCreateDTO(
     ExerciseGroupRef exerciseGroup,
     String filePattern
 ) {
+    /**
+     * Create a file upload exercise DTO pre-filled with default benchmarking values.
+     *
+     * @param title           the title of the exercise.
+     * @param exerciseGroupId the id of the exercise group the exercise belongs to.
+     * @param filePattern     the allowed file pattern for submissions.
+     * @return a new {@link FileUploadExerciseCreateDTO} for benchmarking.
+     */
     public static FileUploadExerciseCreateDTO forBenchmarking(String title, Long exerciseGroupId, String filePattern) {
         return new FileUploadExerciseCreateDTO(
             "file-upload",

--- a/src/main/java/de/tum/cit/aet/artemisModel/ModelingExerciseCreateDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemisModel/ModelingExerciseCreateDTO.java
@@ -11,6 +11,13 @@ public record ModelingExerciseCreateDTO(
     IncludedInOverallScore includedInOverallScore,
     ExerciseGroupRef exerciseGroup
 ) {
+    /**
+     * Create a modeling exercise DTO pre-filled with default benchmarking values.
+     *
+     * @param title           the title of the exercise.
+     * @param exerciseGroupId the id of the exercise group the exercise belongs to.
+     * @return a new {@link ModelingExerciseCreateDTO} for benchmarking.
+     */
     public static ModelingExerciseCreateDTO forBenchmarking(String title, Long exerciseGroupId) {
         return new ModelingExerciseCreateDTO(
             "modeling",

--- a/src/main/java/de/tum/cit/aet/artemisModel/MultipleChoiceQuestionCreateDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemisModel/MultipleChoiceQuestionCreateDTO.java
@@ -15,6 +15,15 @@ public record MultipleChoiceQuestionCreateDTO(
     List<AnswerOptionCreateDTO> answerOptions,
     Boolean singleChoice
 ) {
+    /**
+     * Create a multiple choice question DTO pre-filled with default benchmarking values.
+     *
+     * @param title         the title of the question.
+     * @param text          the question text.
+     * @param points        the points awarded for the question.
+     * @param answerOptions the answer options of the question.
+     * @return a new {@link MultipleChoiceQuestionCreateDTO} for benchmarking.
+     */
     public static MultipleChoiceQuestionCreateDTO forBenchmarking(
         String title,
         String text,

--- a/src/main/java/de/tum/cit/aet/artemisModel/ProgrammingExerciseBuildConfigDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemisModel/ProgrammingExerciseBuildConfigDTO.java
@@ -20,6 +20,11 @@ public record ProgrammingExerciseBuildConfigDTO(
     String branchRegex,
     String buildPlanAccessSecret
 ) {
+    /**
+     * Create a programming exercise build configuration DTO pre-filled with default benchmarking values.
+     *
+     * @return a new {@link ProgrammingExerciseBuildConfigDTO} for benchmarking.
+     */
     public static ProgrammingExerciseBuildConfigDTO forBenchmarking() {
         return new ProgrammingExerciseBuildConfigDTO(
             null,

--- a/src/main/java/de/tum/cit/aet/artemisModel/ProgrammingExerciseCreateDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemisModel/ProgrammingExerciseCreateDTO.java
@@ -23,6 +23,15 @@ public record ProgrammingExerciseCreateDTO(
     CourseRef course,
     ExerciseGroupRef exerciseGroup
 ) {
+    /**
+     * Create a course programming exercise DTO pre-filled with default benchmarking values.
+     *
+     * @param title       the title of the exercise.
+     * @param courseId    the id of the course the exercise belongs to.
+     * @param shortName   the short name of the exercise.
+     * @param packageName the package name of the exercise.
+     * @return a new {@link ProgrammingExerciseCreateDTO} for benchmarking.
+     */
     public static ProgrammingExerciseCreateDTO forCourseBenchmarking(String title, Long courseId, String shortName, String packageName) {
         return new ProgrammingExerciseCreateDTO(
             "programming",
@@ -46,6 +55,15 @@ public record ProgrammingExerciseCreateDTO(
         );
     }
 
+    /**
+     * Create an exam programming exercise DTO pre-filled with default benchmarking values.
+     *
+     * @param title           the title of the exercise.
+     * @param exerciseGroupId the id of the exercise group the exercise belongs to.
+     * @param shortName       the short name of the exercise.
+     * @param packageName     the package name of the exercise.
+     * @return a new {@link ProgrammingExerciseCreateDTO} for benchmarking.
+     */
     public static ProgrammingExerciseCreateDTO forExamBenchmarking(
         String title,
         Long exerciseGroupId,

--- a/src/main/java/de/tum/cit/aet/artemisModel/QuizExerciseCreateDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemisModel/QuizExerciseCreateDTO.java
@@ -13,6 +13,13 @@ public record QuizExerciseCreateDTO(
     Boolean randomizeQuestionOrder,
     List<MultipleChoiceQuestionCreateDTO> quizQuestions
 ) {
+    /**
+     * Create a quiz exercise DTO pre-filled with default benchmarking values.
+     *
+     * @param title     the title of the exercise.
+     * @param questions the multiple choice questions of the quiz.
+     * @return a new {@link QuizExerciseCreateDTO} for benchmarking.
+     */
     public static QuizExerciseCreateDTO forBenchmarking(String title, List<MultipleChoiceQuestionCreateDTO> questions) {
         return new QuizExerciseCreateDTO(
             title,

--- a/src/main/java/de/tum/cit/aet/artemisModel/TextExerciseCreateDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemisModel/TextExerciseCreateDTO.java
@@ -11,6 +11,13 @@ public record TextExerciseCreateDTO(
     IncludedInOverallScore includedInOverallScore,
     ExerciseGroupRef exerciseGroup
 ) {
+    /**
+     * Create a text exercise DTO pre-filled with default benchmarking values.
+     *
+     * @param title           the title of the exercise.
+     * @param exerciseGroupId the id of the exercise group the exercise belongs to.
+     * @return a new {@link TextExerciseCreateDTO} for benchmarking.
+     */
     public static TextExerciseCreateDTO forBenchmarking(String title, Long exerciseGroupId) {
         return new TextExerciseCreateDTO(
             "text",

--- a/src/main/java/de/tum/cit/aet/service/artemis/ArtemisConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/service/artemis/ArtemisConfiguration.java
@@ -292,6 +292,12 @@ public class ArtemisConfiguration {
         };
     }
 
+    /**
+     * Get the configuration of the given Artemis server.
+     *
+     * @param server the Artemis server.
+     * @return the server configuration of the Artemis server.
+     */
     public ArtemisServerConfigurationDTO getServerConfiguration(ArtemisServer server) {
         return new ArtemisServerConfigurationDTO(
             server,


### PR DESCRIPTION
## Summary

`./gradlew checkstyleMain -x webapp` fails with 11 `MissingJavadocMethod` errors. This PR adds the missing Javadoc so the task passes.

### Root cause
The project's `checkstyle.xml` enforces `MissingJavadocMethod` (severity **error**) on public methods of 4+ lines. Eleven public methods lacked Javadoc:

- The `forBenchmarking` / `forCourseBenchmarking` / `forExamBenchmarking` static factory methods on the `*CreateDTO` records (`CourseCreateDTO`, `FileUploadExerciseCreateDTO`, `TextExerciseCreateDTO`, `ModelingExerciseCreateDTO`, `QuizExerciseCreateDTO`, `ProgrammingExerciseBuildConfigDTO`, `MultipleChoiceQuestionCreateDTO`, `ProgrammingExerciseCreateDTO` ×2)
- `ExamUpdateDTO.fromExam(Exam)`
- `ArtemisConfiguration.getServerConfiguration(ArtemisServer)`

These slipped through because **CI does not run `checkstyleMain`** — the `test` workflow only runs `./gradlew test -x webapp`, `prettier:check` and `lint`. The change is documentation-only (80 insertions, 0 deletions).

> Note: consider adding `./gradlew checkstyleMain -x webapp` (and `spotlessCheck`) to CI so this can't regress unnoticed. Left out of this PR to keep it focused.

## Testing
- `./gradlew checkstyleMain -x webapp` ✅ (0 violations, was 11)
- `./gradlew compileJava -x webapp` ✅
- `./gradlew test -x webapp` ✅ (29 tests, 0 failures)
- `pnpm run prettier:check` ✅ (CI gate; includes `.java`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)