### PR TITLE
Update modernizer to 1.14.0 (fix 30 violations) and gradle-git-properties to 4.0.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,13 +21,13 @@ jaxbRuntimeVersion=4.0.9
 
 # gradle plugin version
 jibPluginVersion=3.5.3
-gitPropertiesPluginVersion=2.5.7
+gitPropertiesPluginVersion=4.0.1
 gradleNodePluginVersion=7.1.0
 sonarqubePluginVersion=7.3.1.8318
 spotlessPluginVersion=8.7.0
 openapiPluginVersion=7.23.0
 checkstyleVersion=13.6.0
-modernizerPluginVersion=1.13.0
+modernizerPluginVersion=1.14.0
 
 liquibaseTaskPrefix=liquibase
 liquibasePluginVersion=3.1.0

--- a/src/main/java/de/tum/cit/aet/service/artemis/interaction/SimulatedArtemisStudent.java
+++ b/src/main/java/de/tum/cit/aet/service/artemis/interaction/SimulatedArtemisStudent.java
@@ -842,7 +842,7 @@ public class SimulatedArtemisStudent extends SimulatedArtemisUser {
 
         newContent = newContent.replace("$$1", String.valueOf(new Random().nextInt(100)));
         if (writeToFile) {
-            FileUtils.writeStringToFile(bubbleSort.toFile(), newContent, Charset.defaultCharset());
+            Files.writeString(bubbleSort, newContent, Charset.defaultCharset());
         }
         return newContent;
     }
@@ -1034,7 +1034,7 @@ public class SimulatedArtemisStudent extends SimulatedArtemisUser {
             KeyPair pair;
             pair = new JcaPEMKeyConverter().getKeyPair((PEMKeyPair) parsed);
 
-            return Collections.singleton(pair);
+            return Set.of(pair);
         } catch (Exception e) {
             throw new RuntimeException("Failed to load SSH keys", e);
         }
@@ -1065,7 +1065,7 @@ public class SimulatedArtemisStudent extends SimulatedArtemisUser {
                 new ServerKeyDatabase() {
                     @Override
                     public List<PublicKey> lookup(String connectAddress, InetSocketAddress remoteAddress, Configuration config) {
-                        return Collections.emptyList();
+                        return List.of();
                     }
 
                     @Override

--- a/src/main/java/de/tum/cit/aet/service/mapper/UserMapper.java
+++ b/src/main/java/de/tum/cit/aet/service/mapper/UserMapper.java
@@ -157,7 +157,7 @@ public class UserMapper {
     @Mapping(target = "id", source = "id")
     public Set<UserDTO> toDtoIdSet(Set<User> users) {
         if (users == null) {
-            return Collections.emptySet();
+            return Set.of();
         }
 
         Set<UserDTO> userSet = new HashSet<>();
@@ -200,7 +200,7 @@ public class UserMapper {
     @Mapping(target = "login", source = "login")
     public Set<UserDTO> toDtoLoginSet(Set<User> users) {
         if (users == null) {
-            return Collections.emptySet();
+            return Set.of();
         }
 
         Set<UserDTO> userSet = new HashSet<>();

--- a/src/main/java/de/tum/cit/aet/service/simulation/SimulationExecutionService.java
+++ b/src/main/java/de/tum/cit/aet/service/simulation/SimulationExecutionService.java
@@ -743,7 +743,7 @@ public class SimulationExecutionService {
         if (Thread.currentThread().isInterrupted()) {
             return;
         }
-        var message = String.format(format, args);
+        var message = format.formatted(args);
         if (error) {
             log.error(message);
         } else {

--- a/src/main/java/de/tum/cit/aet/util/TimeLogUtil.java
+++ b/src/main/java/de/tum/cit/aet/util/TimeLogUtil.java
@@ -49,6 +49,6 @@ public class TimeLogUtil {
     }
 
     private static String roundOffTo2DecPlaces(double val) {
-        return String.format("%.2f", val);
+        return "%.2f".formatted(val);
     }
 }

--- a/src/main/java/de/tum/cit/aet/web/websocket/SimulationWebsocketService.java
+++ b/src/main/java/de/tum/cit/aet/web/websocket/SimulationWebsocketService.java
@@ -26,7 +26,7 @@ public class SimulationWebsocketService {
      * @param run the simulation run that was completed
      */
     public void sendSimulationResult(SimulationRun run) {
-        messagingTemplate.convertAndSend(String.format(TOPIC_SIMULATION_RESULT, run.getId()), run.getStats());
+        messagingTemplate.convertAndSend(TOPIC_SIMULATION_RESULT.formatted(run.getId()), run.getStats());
     }
 
     /**
@@ -34,7 +34,7 @@ public class SimulationWebsocketService {
      * @param run the simulation run whose status was updated
      */
     public void sendRunStatusUpdate(SimulationRun run) {
-        messagingTemplate.convertAndSend(String.format(TOPIC_RUN_STATUS_UPDATE, run.getId()), run.getStatus());
+        messagingTemplate.convertAndSend(TOPIC_RUN_STATUS_UPDATE.formatted(run.getId()), run.getStatus());
     }
 
     /**
@@ -43,14 +43,14 @@ public class SimulationWebsocketService {
      * @param logMessage the log message to send
      */
     public void sendRunLogMessage(SimulationRun run, LogMessage logMessage) {
-        messagingTemplate.convertAndSend(String.format(TOPIC_RUN_LOG_MESSAGE, run.getId()), logMessage);
+        messagingTemplate.convertAndSend(TOPIC_RUN_LOG_MESSAGE.formatted(run.getId()), logMessage);
     }
 
     public void sendNewRun(SimulationRun run) {
-        messagingTemplate.convertAndSend(String.format(TOPIC_NEW_RUN, run.getSimulation().getId()), run);
+        messagingTemplate.convertAndSend(TOPIC_NEW_RUN.formatted(run.getSimulation().getId()), run);
     }
 
     public void sendRunCiUpdate(long runId, CiStatus status) {
-        messagingTemplate.convertAndSend(String.format(TOPIC_RUN_CI_UPDATE, runId), status);
+        messagingTemplate.convertAndSend(TOPIC_RUN_CI_UPDATE.formatted(runId), status);
     }
 }

--- a/src/test/java/de/tum/cit/aet/config/MysqlTestContainer.java
+++ b/src/test/java/de/tum/cit/aet/config/MysqlTestContainer.java
@@ -1,6 +1,6 @@
 package de.tum.cit.aet.config;
 
-import java.util.Collections;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.JdbcDatabaseContainer;
@@ -25,7 +25,7 @@ public class MysqlTestContainer implements SqlTestContainer {
         if (null == mysqlContainer) {
             mysqlContainer = new MySQLContainer("mysql:9.7.0")
                 .withDatabaseName("artemis-benchmarking")
-                .withTmpFs(Collections.singletonMap("/testtmpfs", "rw"))
+                .withTmpFs(Map.of("/testtmpfs", "rw"))
                 .withLogConsumer(new Slf4jLogConsumer(log))
                 .withReuse(true);
         }

--- a/src/test/java/de/tum/cit/aet/config/WebConfigurerTest.java
+++ b/src/test/java/de/tum/cit/aet/config/WebConfigurerTest.java
@@ -61,9 +61,9 @@ class WebConfigurerTest {
 
     @Test
     void shouldCorsFilterOnOtherPath() throws Exception {
-        corsConfiguration.setAllowedOrigins(Collections.singletonList("*"));
+        corsConfiguration.setAllowedOrigins(List.of("*"));
         corsConfiguration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE"));
-        corsConfiguration.setAllowedHeaders(Collections.singletonList("*"));
+        corsConfiguration.setAllowedHeaders(List.of("*"));
         corsConfiguration.setMaxAge(1800L);
         corsConfiguration.setAllowCredentials(true);
 

--- a/src/test/java/de/tum/cit/aet/config/timezone/HibernateTimeZoneIT.java
+++ b/src/test/java/de/tum/cit/aet/config/timezone/HibernateTimeZoneIT.java
@@ -1,6 +1,5 @@
 package de.tum.cit.aet.config.timezone;
 
-import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import de.tum.cit.aet.IntegrationTest;
@@ -154,7 +153,7 @@ class HibernateTimeZoneIT {
     }
 
     private String generateSqlRequest(String fieldName, long id) {
-        return format("SELECT %s FROM jhi_date_time_wrapper where id=%d", fieldName, id);
+        return "SELECT %s FROM jhi_date_time_wrapper where id=%d".formatted(fieldName, id);
     }
 
     private void assertThatValueFromSqlRowSetIsEqualToExpectedValue(SqlRowSet sqlRowSet, String expectedValue) {

--- a/src/test/java/de/tum/cit/aet/security/jwt/JwtAuthenticationTestUtils.java
+++ b/src/test/java/de/tum/cit/aet/security/jwt/JwtAuthenticationTestUtils.java
@@ -8,7 +8,7 @@ import com.nimbusds.jose.util.Base64;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Instant;
-import java.util.Collections;
+import java.util.List;
 import javax.crypto.Mac;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -42,7 +42,7 @@ public class JwtAuthenticationTestUtils {
             .issuedAt(now)
             .expiresAt(now.plusSeconds(60))
             .subject(user)
-            .claims(customClain -> customClain.put(AUTHORITIES_KEY, Collections.singletonList("ROLE_ADMIN")))
+            .claims(customClain -> customClain.put(AUTHORITIES_KEY, List.of("ROLE_ADMIN")))
             .build();
 
         JwsHeader jwsHeader = JwsHeader.with(JWT_ALGORITHM).build();

--- a/src/test/java/de/tum/cit/aet/web/rest/AccountResourceIT.java
+++ b/src/test/java/de/tum/cit/aet/web/rest/AccountResourceIT.java
@@ -147,7 +147,7 @@ class AccountResourceIT {
         userDTO.setActivated(false);
         userDTO.setImageUrl("http://placehold.it/50x50");
         userDTO.setLangKey(Constants.DEFAULT_LANGUAGE);
-        userDTO.setAuthorities(Collections.singleton(AuthoritiesConstants.ADMIN));
+        userDTO.setAuthorities(Set.of(AuthoritiesConstants.ADMIN));
 
         restAccountMockMvc
             .perform(post("/api/account").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(userDTO)))
@@ -184,7 +184,7 @@ class AccountResourceIT {
         userDTO.setActivated(false);
         userDTO.setImageUrl("http://placehold.it/50x50");
         userDTO.setLangKey(Constants.DEFAULT_LANGUAGE);
-        userDTO.setAuthorities(Collections.singleton(AuthoritiesConstants.ADMIN));
+        userDTO.setAuthorities(Set.of(AuthoritiesConstants.ADMIN));
 
         restAccountMockMvc
             .perform(post("/api/account").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(userDTO)))
@@ -220,7 +220,7 @@ class AccountResourceIT {
         userDTO.setActivated(false);
         userDTO.setImageUrl("http://placehold.it/50x50");
         userDTO.setLangKey(Constants.DEFAULT_LANGUAGE);
-        userDTO.setAuthorities(Collections.singleton(AuthoritiesConstants.ADMIN));
+        userDTO.setAuthorities(Set.of(AuthoritiesConstants.ADMIN));
 
         restAccountMockMvc
             .perform(post("/api/account").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(userDTO)))
@@ -249,7 +249,7 @@ class AccountResourceIT {
         userDTO.setActivated(false);
         userDTO.setImageUrl("http://placehold.it/50x50");
         userDTO.setLangKey(Constants.DEFAULT_LANGUAGE);
-        userDTO.setAuthorities(Collections.singleton(AuthoritiesConstants.ADMIN));
+        userDTO.setAuthorities(Set.of(AuthoritiesConstants.ADMIN));
 
         restAccountMockMvc
             .perform(post("/api/account").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(userDTO)))

--- a/src/test/java/de/tum/cit/aet/web/rest/UserResourceIT.java
+++ b/src/test/java/de/tum/cit/aet/web/rest/UserResourceIT.java
@@ -130,7 +130,7 @@ class UserResourceIT {
         user.setActivated(true);
         user.setImageUrl(DEFAULT_IMAGEURL);
         user.setLangKey(DEFAULT_LANGKEY);
-        user.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
+        user.setAuthorities(Set.of(AuthoritiesConstants.USER));
 
         restUserMockMvc
             .perform(post("/api/admin/users").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(user)))
@@ -163,7 +163,7 @@ class UserResourceIT {
         user.setActivated(true);
         user.setImageUrl(DEFAULT_IMAGEURL);
         user.setLangKey(DEFAULT_LANGKEY);
-        user.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
+        user.setAuthorities(Set.of(AuthoritiesConstants.USER));
 
         // An entity with an existing ID cannot be created, so this API call must fail
         restUserMockMvc
@@ -189,7 +189,7 @@ class UserResourceIT {
         user.setActivated(true);
         user.setImageUrl(DEFAULT_IMAGEURL);
         user.setLangKey(DEFAULT_LANGKEY);
-        user.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
+        user.setAuthorities(Set.of(AuthoritiesConstants.USER));
 
         // Create the User
         restUserMockMvc
@@ -215,7 +215,7 @@ class UserResourceIT {
         user.setActivated(true);
         user.setImageUrl(DEFAULT_IMAGEURL);
         user.setLangKey(DEFAULT_LANGKEY);
-        user.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
+        user.setAuthorities(Set.of(AuthoritiesConstants.USER));
 
         // Create the User
         restUserMockMvc
@@ -297,7 +297,7 @@ class UserResourceIT {
         user.setCreatedDate(updatedUser.getCreatedDate());
         user.setLastModifiedBy(updatedUser.getLastModifiedBy());
         user.setLastModifiedDate(updatedUser.getLastModifiedDate());
-        user.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
+        user.setAuthorities(Set.of(AuthoritiesConstants.USER));
 
         restUserMockMvc
             .perform(put("/api/admin/users").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(user)))
@@ -342,7 +342,7 @@ class UserResourceIT {
         user.setCreatedDate(updatedUser.getCreatedDate());
         user.setLastModifiedBy(updatedUser.getLastModifiedBy());
         user.setLastModifiedDate(updatedUser.getLastModifiedDate());
-        user.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
+        user.setAuthorities(Set.of(AuthoritiesConstants.USER));
 
         restUserMockMvc
             .perform(put("/api/admin/users").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(user)))
@@ -398,7 +398,7 @@ class UserResourceIT {
         user.setCreatedDate(updatedUser.getCreatedDate());
         user.setLastModifiedBy(updatedUser.getLastModifiedBy());
         user.setLastModifiedDate(updatedUser.getLastModifiedDate());
-        user.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
+        user.setAuthorities(Set.of(AuthoritiesConstants.USER));
 
         restUserMockMvc
             .perform(put("/api/admin/users").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(user)))
@@ -438,7 +438,7 @@ class UserResourceIT {
         user.setCreatedDate(updatedUser.getCreatedDate());
         user.setLastModifiedBy(updatedUser.getLastModifiedBy());
         user.setLastModifiedDate(updatedUser.getLastModifiedDate());
-        user.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
+        user.setAuthorities(Set.of(AuthoritiesConstants.USER));
 
         restUserMockMvc
             .perform(put("/api/admin/users").contentType(MediaType.APPLICATION_JSON).content(TestUtil.convertObjectToJsonBytes(user)))
@@ -490,7 +490,7 @@ class UserResourceIT {
         userDTO.setLangKey(DEFAULT_LANGKEY);
         userDTO.setCreatedBy(DEFAULT_LOGIN);
         userDTO.setLastModifiedBy(DEFAULT_LOGIN);
-        userDTO.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
+        userDTO.setAuthorities(Set.of(AuthoritiesConstants.USER));
 
         User user = userMapper.userDTOToUser(userDTO);
         assertThat(user.getId()).isEqualTo(DEFAULT_ID);


### PR DESCRIPTION
## Summary

Updates two Gradle plugins that were held back from #778 because their bumps were breaking, and fixes the fallout.

### `com.github.andygoossens.gradle-modernizer-plugin` 1.13.0 → 1.14.0
The new version reports **30** new violations against existing code (`modernizer { failOnViolations = true }`). All 30 are fixed by preferring modern JDK APIs:

| Legacy | Modern | Sites |
| --- | --- | --- |
| `String.format(fmt, args)` | `fmt.formatted(args)` | 8 |
| `FileUtils.writeStringToFile(file, s, cs)` | `Files.writeString(path, s, cs)` | 1 |
| `Collections.singleton(x)` / `emptySet()` | `Set.of(x)` / `Set.of()` | 14 |
| `Collections.singletonList(x)` / `emptyList()` | `List.of(x)` / `List.of()` | 6 |
| `Collections.singletonMap(k, v)` | `Map.of(k, v)` | 1 |

Unused imports (`Collections`, static `String.format`) were removed; `FileUtils` stays (still used elsewhere).

### `gradle-git-properties` 2.5.7 → 4.0.1
Major version bump. Verified the `GenerateGitPropertiesTask` API in `build.gradle` is unchanged and `git.properties` is still generated correctly with all expected fields.

## Testing
- `./gradlew modernizer -x webapp` ✅ (0 violations, was 30)
- `./gradlew generateGitProperties -x webapp` ✅ (`build/resources/main/git.properties` generated)
- `./gradlew compileJava compileTestJava -x webapp` ✅
- `./gradlew test -x webapp` ✅ (29 tests, 0 failures)
- `./gradlew spotlessCheck -x webapp` ✅
- `pnpm run prettier:check` ✅ (CI gate; includes `.java`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)