### PR TITLE
Update pnpm to 11.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.1.2
+          version: 11.7.0
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ profile=dev
 
 # Build properties
 node_version=24.15.0
-pnpm_version=11.1.2
+pnpm_version=11.7.0
 
 # Dependency versions
 springBootVersion=4.1.0

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "typescript": "5.9.3",
     "typescript-eslint": "8.61.1"
   },
-  "packageManager": "pnpm@11.1.2",
+  "packageManager": "pnpm@11.7.0",
   "engines": {
     "node": ">=24.15.0",
     "pnpm": ">=11.1.0 <12.0.0"


### PR DESCRIPTION
## Summary

Updates the pinned pnpm version to **11.7.0** (the current `latest` — there is no pnpm 12 yet), a non-breaking bump within major 11. Updated in all three places pnpm is pinned so local, Gradle-driven and CI installs stay in sync:

- `package.json` → `packageManager: "pnpm@11.7.0"`
- `gradle.properties` → `pnpm_version=11.7.0` (gradle node plugin)
- `.github/workflows/ci.yml` → `pnpm/action-setup` `version: 11.7.0`

The `engines` constraint (`>=11.1.0 <12.0.0`) still holds. **The lockfile is unchanged** (`pnpm install` reports it up to date; `lockfileVersion` stays `9.0`), and `pnpm-workspace.yaml` is untouched (pnpm 11.7's supply-chain policy check passes cleanly — no `minimumReleaseAgeExclude` entries needed).

## Testing (all run with pnpm 11.7.0)
- `pnpm install --frozen-lockfile` ✅ (already up to date)
- `pnpm run lint` ✅
- `pnpm run prettier:check` ✅
- `pnpm run webapp:build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)