### PR TITLE
Handle management/info failures gracefully in ProfileService

### DIFF
--- a/src/main/webapp/app/layouts/profiles/profile.service.ts
+++ b/src/main/webapp/app/layouts/profiles/profile.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { map, shareReplay } from 'rxjs/operators';
-import { Observable } from 'rxjs';
+import { catchError, map, shareReplay } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
 
 import { ApplicationConfigService } from 'app/core/config/application-config.service';
 import { InfoResponse, ProfileInfo } from './profile-info.model';
@@ -36,6 +36,10 @@ export class ProfileService {
         }
         return profileInfo;
       }),
+      // If the management/info endpoint is unavailable (e.g. backend not reachable),
+      // degrade gracefully to default profile info instead of letting the error
+      // propagate uncaught to every subscriber (navbar, footer, page-ribbon, ...).
+      catchError(() => of(new ProfileInfo())),
       shareReplay(),
     );
     return this.profileInfo$;


### PR DESCRIPTION
## Summary

`ProfileService.getProfileInfo()` fetched `/management/info` with no error handling. When that request fails or returns a non-JSON body (e.g. the backend is unreachable, or the SPA is served standalone), the error propagated **uncaught** to every subscriber — navbar, footer, page-ribbon, create-simulation-box — and each surfaced in Angular's global `ErrorHandler`. On the anonymous landing page that's 3 active subscribers ⇒ 3 console errors.

This mirrors the resilience `AccountService.identity()` already has (`catchError(() => of(undefined))`): on failure, degrade gracefully to a default `ProfileInfo` instead of throwing.

```ts
.pipe(
  map(...),
  catchError(() => of(new ProfileInfo())), // <- added
  shareReplay(),
)
```

### Context
This surfaced while smoke-testing the Angular 22 PR (#784) by serving the production bundle without a backend: the 3 console errors were all from this missing `catchError` (the `/api/account` 401 path was already handled). It is **pre-existing** and unrelated to the Angular version — in normal deployments `/management/info` returns JSON, so it never fired. The fix makes the app robust when it doesn't.

## Testing
- Production build (`pnpm run webapp:prod`) ✅
- Served the prod bundle and loaded it in a browser with **no backend**: **0 console errors** (was 3); navbar/footer/landing render unchanged.
- `pnpm run lint` ✅ · `pnpm run prettier:check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)