### PR TITLE
Update prettier-plugin-java to 2.9.7 and other dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     restart: always
 
   mysql:
-    image: mysql:9.7.0
+    image: mysql:9.7.1
     volumes:
       - artemis-mysql-data:/var/lib/mysql
     env_file:

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "husky": "9.1.7",
     "lint-staged": "17.0.7",
     "prettier": "3.8.4",
-    "prettier-plugin-java": "2.8.1",
+    "prettier-plugin-java": "2.9.7",
     "prettier-plugin-packagejson": "3.0.2",
     "rimraf": "6.1.3",
     "sass": "1.101.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,9 +27,9 @@ overrides:
   punycode: 2.3.1
   rimraf: 6.1.3
   tough-cookie: 6.0.1
-  webpack: 5.106.2
+  webpack: 5.107.2
   webpack-dev-middleware: 8.0.3
-  webpack-dev-server: 5.2.3
+  webpack-dev-server: 5.2.5
   word-wrap: 1.2.5
   ws: 8.21.0
   yargs-parser: 22.0.0
@@ -157,8 +157,8 @@ importers:
         specifier: 3.8.4
         version: 3.8.4
       prettier-plugin-java:
-        specifier: 2.8.1
-        version: 2.8.1(prettier@3.8.4)
+        specifier: 2.9.7
+        version: 2.9.7(prettier@3.8.4)
       prettier-plugin-packagejson:
         specifier: 3.0.2
         version: 3.0.2(prettier@3.8.4)
@@ -285,8 +285,8 @@ packages:
     resolution: {integrity: sha512-rw5I9iInUkApAhDrWJavhk23kxkQ02HoEKwPgvVERAW0mr+q36HrVFEAlaQM9YV5GjxOPt67nrVFY0SrVgYGbg==}
     engines: {node: ^22.22.3 || ^24.15.0 || >=26.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     peerDependencies:
-      webpack: 5.106.2
-      webpack-dev-server: 5.2.3
+      webpack: 5.107.2
+      webpack-dev-server: 5.2.5
 
   '@angular-devkit/core@22.0.1':
     resolution: {integrity: sha512-77/WsCAbqGkumDfm/kkw2mFh/42DNF0hB02TvivlfiSC/KfK9DsHg7sKvTlNcuY14ZT/3iHhojLyNBc2HytuvQ==}
@@ -1059,21 +1059,6 @@ packages:
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
-  '@chevrotain/cst-dts-gen@11.0.3':
-    resolution: {integrity: sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==}
-
-  '@chevrotain/gast@11.0.3':
-    resolution: {integrity: sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==}
-
-  '@chevrotain/regexp-to-ast@11.0.3':
-    resolution: {integrity: sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==}
-
-  '@chevrotain/types@11.0.3':
-    resolution: {integrity: sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==}
-
-  '@chevrotain/utils@11.0.3':
-    resolution: {integrity: sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==}
-
   '@discoveryjs/json-ext@1.1.0':
     resolution: {integrity: sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA==}
     engines: {node: '>=14.17.0'}
@@ -1827,7 +1812,7 @@ packages:
     peerDependencies:
       '@angular/compiler-cli': ^22.0.0
       typescript: '>=6.0 <6.1'
-      webpack: 5.106.2
+      webpack: 5.107.2
 
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
@@ -2383,9 +2368,6 @@ packages:
   '@types/d3-time@3.0.4':
     resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
 
-  '@types/eslint-scope@3.7.7':
-    resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
-
   '@types/eslint@9.6.1':
     resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
 
@@ -2700,7 +2682,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.12.0 || ^8.0.0-beta.1
       '@rspack/core': ^1.0.0 || ^2.0.0-0
-      webpack: 5.106.2
+      webpack: 5.107.2
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
@@ -2819,14 +2801,6 @@ packages:
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
-  chevrotain-allstar@0.3.1:
-    resolution: {integrity: sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==}
-    peerDependencies:
-      chevrotain: ^11.0.0
-
-  chevrotain@11.0.3:
-    resolution: {integrity: sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==}
-
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
@@ -2923,7 +2897,7 @@ packages:
     resolution: {integrity: sha512-3JLW90aBGeaTLpM7mYQKpnVdgsUZRExY55giiZgLuX/xTQRUs1dOCwbBnWnvY6Q6rfZoXMNwzOQJCSZPppfqXA==}
     engines: {node: '>= 20.9.0'}
     peerDependencies:
-      webpack: 5.106.2
+      webpack: 5.107.2
 
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
@@ -2953,7 +2927,7 @@ packages:
     engines: {node: '>= 18.12.0'}
     peerDependencies:
       '@rspack/core': 0.x || ^1.0.0 || ^2.0.0-0
-      webpack: 5.106.2
+      webpack: 5.107.2
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
@@ -3142,8 +3116,8 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
-  enhanced-resolve@5.21.3:
-    resolution: {integrity: sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==}
+  enhanced-resolve@5.24.0:
+    resolution: {integrity: sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==}
     engines: {node: '>=10.13.0'}
 
   entities@4.5.0:
@@ -3727,9 +3701,6 @@ packages:
     resolution: {integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==}
     engines: {node: '>=10'}
 
-  java-parser@3.0.1:
-    resolution: {integrity: sha512-sDIR7u9b7O2JViNUxiZRhnRz7URII/eE7g2B+BmGxDeS6Ex3OYAcCyz5oh0H4LQ+hL/BS8OJTz8apMy9xtGmrQ==}
-
   jest-worker@27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
@@ -3806,7 +3777,7 @@ packages:
     peerDependencies:
       '@rspack/core': 0.x || ^1.0.0 || ^2.0.0-0
       less: ^3.5.0 || ^4.0.0
-      webpack: 5.106.2
+      webpack: 5.107.2
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
@@ -3862,14 +3833,8 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
-  lodash-es@4.18.1:
-    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
-
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
-
-  lodash@4.18.1:
-    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   log-symbols@7.0.1:
     resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
@@ -3950,7 +3915,7 @@ packages:
     resolution: {integrity: sha512-AOSS0IdEB95ayVkxn5oGzNQwqAi2J0Jb/kKm43t7H73s8+f5873g0yuj0PNvK4dO75mu5DHg4nlgp4k6Kga8eg==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
-      webpack: 5.106.2
+      webpack: 5.107.2
 
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
@@ -4254,7 +4219,7 @@ packages:
     peerDependencies:
       '@rspack/core': 0.x || ^1.0.0 || ^2.0.0-0
       postcss: 8.5.15
-      webpack: 5.106.2
+      webpack: 5.107.2
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
@@ -4317,8 +4282,8 @@ packages:
     resolution: {integrity: sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==}
     engines: {node: '>=6.0.0'}
 
-  prettier-plugin-java@2.8.1:
-    resolution: {integrity: sha512-tkteH5OSCEb0E7wKnhhUSitr1pGUCUt9M//CwerSNhoalL/qv0jXTeSVBPZ36KC+kZl3nbq4dxh144NuGchACg==}
+  prettier-plugin-java@2.9.7:
+    resolution: {integrity: sha512-5ifIseGcpuBizlGw9bUZPoyRPj8c9TV2g2jfO+70Dt92ZH5XG39iXZ4qyGTXN7OTdEprqJjHYQ8UWZcfDc4P9Q==}
     peerDependencies:
       prettier: ^3.0.0
 
@@ -4489,7 +4454,7 @@ packages:
       node-sass: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
       sass: ^1.3.0
       sass-embedded: '*'
-      webpack: 5.106.2
+      webpack: 5.107.2
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
@@ -4643,7 +4608,7 @@ packages:
     resolution: {integrity: sha512-k2Dur7CbSLcAH73sBcIkV5xjPV4SzqO1NJ7+XaQl8if3VODDUj3FNchNGpqgJSKbvUfJuhVdv8K2Eu8/TNl2eA==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
-      webpack: 5.106.2
+      webpack: 5.107.2
 
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
@@ -4750,7 +4715,7 @@ packages:
       lightningcss: '*'
       postcss: '*'
       uglify-js: '*'
-      webpack: 5.106.2
+      webpack: 5.107.2
     peerDependenciesMeta:
       '@minify-html/node':
         optional: true
@@ -4776,11 +4741,6 @@ packages:
         optional: true
       uglify-js:
         optional: true
-
-  terser@5.46.0:
-    resolution: {integrity: sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==}
-    engines: {node: '>=10'}
-    hasBin: true
 
   terser@5.46.2:
     resolution: {integrity: sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==}
@@ -4969,21 +4929,24 @@ packages:
   weak-lru-cache@1.2.2:
     resolution: {integrity: sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==}
 
+  web-tree-sitter@0.26.9:
+    resolution: {integrity: sha512-YJwSHANl6XFgeEjB8nitgj0qZYt5gkIesJ4w2srS2wcLB4GUa4xcOkM0YaMsU6WNR53YVIkDSY7Ej4pf3IXtCA==}
+
   webpack-dev-middleware@8.0.3:
     resolution: {integrity: sha512-zWrde9VZDiRaFuWsjHO40wm9LxxtXEk8DdzFXdU7eU5ZpiANnZZDBbZgN3guxbEoKqUHd9YupBmynyioz42nkA==}
     engines: {node: '>= 20.9.0'}
     peerDependencies:
-      webpack: 5.106.2
+      webpack: 5.107.2
     peerDependenciesMeta:
       webpack:
         optional: true
 
-  webpack-dev-server@5.2.3:
-    resolution: {integrity: sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==}
+  webpack-dev-server@5.2.5:
+    resolution: {integrity: sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==}
     engines: {node: '>= 18.12.0'}
     hasBin: true
     peerDependencies:
-      webpack: 5.106.2
+      webpack: 5.107.2
       webpack-cli: '*'
     peerDependenciesMeta:
       webpack:
@@ -4999,18 +4962,22 @@ packages:
     resolution: {integrity: sha512-eACpxRN02yaawnt+uUNIF7Qje6A9zArxBbcAJjK1PK3S9Ycg5jIuJ8pW4q8EMnwNZCEGltcjkRx1QzOxOkKD8A==}
     engines: {node: '>=10.13.0'}
 
+  webpack-sources@3.5.0:
+    resolution: {integrity: sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==}
+    engines: {node: '>=10.13.0'}
+
   webpack-subresource-integrity@5.1.0:
     resolution: {integrity: sha512-sacXoX+xd8r4WKsy9MvH/q/vBtEHr86cpImXwyg74pFIpERKt6FmB8cXpeuh0ZLgclOlHI4Wcll7+R5L02xk9Q==}
     engines: {node: '>= 12'}
     peerDependencies:
       html-webpack-plugin: '>= 5.0.0-beta.1 < 6'
-      webpack: 5.106.2
+      webpack: 5.107.2
     peerDependenciesMeta:
       html-webpack-plugin:
         optional: true
 
-  webpack@5.106.2:
-    resolution: {integrity: sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==}
+  webpack@5.107.2:
+    resolution: {integrity: sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -5223,7 +5190,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2200.1(chokidar@5.0.0)
-      '@angular-devkit/build-webpack': 0.2200.1(chokidar@5.0.0)(webpack-dev-server@5.2.3(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15)))(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15))
+      '@angular-devkit/build-webpack': 0.2200.1(chokidar@5.0.0)(webpack-dev-server@5.2.5(tslib@2.8.1)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)))(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
       '@angular-devkit/core': 22.0.1(chokidar@5.0.0)
       '@angular/build': 22.0.1(@angular/compiler-cli@22.0.1(@angular/compiler@22.0.1)(typescript@6.0.3))(@angular/compiler@22.0.1)(@angular/core@22.0.1(@angular/compiler@22.0.1)(rxjs@7.8.2))(@angular/localize@22.0.1(@angular/compiler-cli@22.0.1(@angular/compiler@22.0.1)(typescript@6.0.3))(@angular/compiler@22.0.1))(@angular/platform-browser@22.0.1(@angular/animations@22.0.1(@angular/core@22.0.1(@angular/compiler@22.0.1)(rxjs@7.8.2)))(@angular/common@22.0.1(@angular/core@22.0.1(@angular/compiler@22.0.1)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.1(@angular/compiler@22.0.1)(rxjs@7.8.2)))(@angular/service-worker@22.0.1(@angular/core@22.0.1(@angular/compiler@22.0.1)(rxjs@7.8.2))(rxjs@7.8.2))(@types/node@25.9.3)(chokidar@5.0.0)(istanbul-lib-instrument@6.0.3)(jiti@2.7.0)(less@4.6.4)(postcss@8.5.15)(terser@5.46.2)(tslib@2.8.1)(typescript@6.0.3)(yaml@2.9.0)
       '@angular/compiler-cli': 22.0.1(@angular/compiler@22.0.1)(typescript@6.0.3)
@@ -5237,45 +5204,45 @@ snapshots:
       '@babel/preset-env': 7.29.3(@babel/core@7.29.0)
       '@babel/runtime': 7.29.2
       '@discoveryjs/json-ext': 1.1.0
-      '@ngtools/webpack': 22.0.1(@angular/compiler-cli@22.0.1(@angular/compiler@22.0.1)(typescript@6.0.3))(typescript@6.0.3)(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15))
+      '@ngtools/webpack': 22.0.1(@angular/compiler-cli@22.0.1(@angular/compiler@22.0.1)(typescript@6.0.3))(typescript@6.0.3)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
       ansi-colors: 4.1.3
       autoprefixer: 10.5.0(postcss@8.5.15)
-      babel-loader: 10.1.1(@babel/core@7.29.0)(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15))
+      babel-loader: 10.1.1(@babel/core@7.29.0)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
       browserslist: 4.28.2
-      copy-webpack-plugin: 14.0.0(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15))
-      css-loader: 7.1.4(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15))
+      copy-webpack-plugin: 14.0.0(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
+      css-loader: 7.1.4(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
       esbuild-wasm: 0.28.0
       http-proxy-middleware: 3.0.5
       istanbul-lib-instrument: 6.0.3
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.6.4
-      less-loader: 12.3.2(less@4.6.4)(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15))
-      license-webpack-plugin: 4.0.2(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15))
+      less-loader: 12.3.2(less@4.6.4)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
+      license-webpack-plugin: 4.0.2(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.10.2(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15))
+      mini-css-extract-plugin: 2.10.2(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
       open: 11.0.0
       ora: 9.4.0
       picomatch: 4.0.4
       piscina: 5.1.4
       postcss: 8.5.15
-      postcss-loader: 8.2.1(postcss@8.5.15)(typescript@6.0.3)(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15))
+      postcss-loader: 8.2.1(postcss@8.5.15)(typescript@6.0.3)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
       resolve-url-loader: 5.0.0
       rxjs: 7.8.2
       sass: 1.99.0
-      sass-loader: 16.0.7(sass@1.99.0)(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15))
+      sass-loader: 16.0.7(sass@1.99.0)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
       semver: 7.7.4
-      source-map-loader: 5.0.0(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15))
+      source-map-loader: 5.0.0(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
       source-map-support: 0.5.21
       terser: 5.46.2
       tinyglobby: 0.2.16
       tslib: 2.8.1
       typescript: 6.0.3
-      webpack: 5.106.2(esbuild@0.28.1)(postcss@8.5.15)
-      webpack-dev-middleware: 8.0.3(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15))
-      webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15))
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
+      webpack-dev-middleware: 8.0.3(tslib@2.8.1)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
+      webpack-dev-server: 5.2.5(tslib@2.8.1)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15))
+      webpack-subresource-integrity: 5.1.0(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
     optionalDependencies:
       '@angular/core': 22.0.1(@angular/compiler@22.0.1)(rxjs@7.8.2)
       '@angular/localize': 22.0.1(@angular/compiler-cli@22.0.1(@angular/compiler@22.0.1)(typescript@6.0.3))(@angular/compiler@22.0.1)
@@ -5312,12 +5279,12 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@angular-devkit/build-webpack@0.2200.1(chokidar@5.0.0)(webpack-dev-server@5.2.3(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15)))(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15))':
+  '@angular-devkit/build-webpack@0.2200.1(chokidar@5.0.0)(webpack-dev-server@5.2.5(tslib@2.8.1)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)))(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))':
     dependencies:
       '@angular-devkit/architect': 0.2200.1(chokidar@5.0.0)
       rxjs: 7.8.2
-      webpack: 5.106.2(esbuild@0.28.1)(postcss@8.5.15)
-      webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15))
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
+      webpack-dev-server: 5.2.5(tslib@2.8.1)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
     transitivePeerDependencies:
       - chokidar
 
@@ -6319,23 +6286,6 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@chevrotain/cst-dts-gen@11.0.3':
-    dependencies:
-      '@chevrotain/gast': 11.0.3
-      '@chevrotain/types': 11.0.3
-      lodash-es: 4.18.1
-
-  '@chevrotain/gast@11.0.3':
-    dependencies:
-      '@chevrotain/types': 11.0.3
-      lodash-es: 4.18.1
-
-  '@chevrotain/regexp-to-ast@11.0.3': {}
-
-  '@chevrotain/types@11.0.3': {}
-
-  '@chevrotain/utils@11.0.3': {}
-
   '@discoveryjs/json-ext@1.1.0': {}
 
   '@esbuild/aix-ppc64@0.28.1':
@@ -6927,11 +6877,11 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@ngtools/webpack@22.0.1(@angular/compiler-cli@22.0.1(@angular/compiler@22.0.1)(typescript@6.0.3))(typescript@6.0.3)(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15))':
+  '@ngtools/webpack@22.0.1(@angular/compiler-cli@22.0.1(@angular/compiler@22.0.1)(typescript@6.0.3))(typescript@6.0.3)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))':
     dependencies:
       '@angular/compiler-cli': 22.0.1(@angular/compiler@22.0.1)(typescript@6.0.3)
       typescript: 6.0.3
-      webpack: 5.106.2(esbuild@0.28.1)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
 
   '@noble/hashes@1.4.0': {}
 
@@ -7441,15 +7391,11 @@ snapshots:
 
   '@types/d3-time@3.0.4': {}
 
-  '@types/eslint-scope@3.7.7':
-    dependencies:
-      '@types/eslint': 9.6.1
-      '@types/estree': 1.0.9
-
   '@types/eslint@9.6.1':
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
+    optional: true
 
   '@types/esrecurse@4.3.1': {}
 
@@ -7829,12 +7775,12 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  babel-loader@10.1.1(@babel/core@7.29.0)(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15)):
+  babel-loader@10.1.1(@babel/core@7.29.0)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
       '@babel/core': 7.29.0
       find-up: 5.0.0
     optionalDependencies:
-      webpack: 5.106.2(esbuild@0.28.1)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
 
   babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0):
     dependencies:
@@ -7972,20 +7918,6 @@ snapshots:
 
   chardet@2.1.1: {}
 
-  chevrotain-allstar@0.3.1(chevrotain@11.0.3):
-    dependencies:
-      chevrotain: 11.0.3
-      lodash-es: 4.18.1
-
-  chevrotain@11.0.3:
-    dependencies:
-      '@chevrotain/cst-dts-gen': 11.0.3
-      '@chevrotain/gast': 11.0.3
-      '@chevrotain/regexp-to-ast': 11.0.3
-      '@chevrotain/types': 11.0.3
-      '@chevrotain/utils': 11.0.3
-      lodash-es: 4.18.1
-
   chokidar@3.6.0:
     dependencies:
       anymatch: 3.1.3
@@ -8075,14 +8007,14 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
-  copy-webpack-plugin@14.0.0(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15)):
+  copy-webpack-plugin@14.0.0(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
       tinyglobby: 0.2.16
-      webpack: 5.106.2(esbuild@0.28.1)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
 
   core-js-compat@3.49.0:
     dependencies:
@@ -8110,7 +8042,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-loader@7.1.4(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15)):
+  css-loader@7.1.4(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.15)
       postcss: 8.5.15
@@ -8121,7 +8053,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.8.0
     optionalDependencies:
-      webpack: 5.106.2(esbuild@0.28.1)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
 
   css-select@6.0.0:
     dependencies:
@@ -8284,7 +8216,7 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
-  enhanced-resolve@5.21.3:
+  enhanced-resolve@5.24.0:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
@@ -8863,12 +8795,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  java-parser@3.0.1:
-    dependencies:
-      chevrotain: 11.0.3
-      chevrotain-allstar: 0.3.1(chevrotain@11.0.3)
-      lodash: 4.18.1
-
   jest-worker@27.5.1:
     dependencies:
       '@types/node': 25.9.3
@@ -8922,11 +8848,11 @@ snapshots:
       picocolors: 1.1.1
       shell-quote: 1.8.3
 
-  less-loader@12.3.2(less@4.6.4)(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15)):
+  less-loader@12.3.2(less@4.6.4)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
       less: 4.6.4
     optionalDependencies:
-      webpack: 5.106.2(esbuild@0.28.1)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
 
   less@4.6.4:
     dependencies:
@@ -8946,11 +8872,11 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  license-webpack-plugin@4.0.2(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15)):
+  license-webpack-plugin@4.0.2(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
       webpack-sources: 3.4.1
     optionalDependencies:
-      webpack: 5.106.2(esbuild@0.28.1)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
 
   lines-and-columns@1.2.4: {}
 
@@ -9003,11 +8929,7 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lodash-es@4.18.1: {}
-
   lodash.debounce@4.0.8: {}
-
-  lodash@4.18.1: {}
 
   log-symbols@7.0.1:
     dependencies:
@@ -9102,11 +9024,11 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
-  mini-css-extract-plugin@2.10.2(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15)):
+  mini-css-extract-plugin@2.10.2(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.3
-      webpack: 5.106.2(esbuild@0.28.1)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
 
   minimalistic-assert@1.0.1: {}
 
@@ -9445,14 +9367,14 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  postcss-loader@8.2.1(postcss@8.5.15)(typescript@6.0.3)(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15)):
+  postcss-loader@8.2.1(postcss@8.5.15)(typescript@6.0.3)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
       cosmiconfig: 9.0.1(typescript@6.0.3)
       jiti: 2.7.0
       postcss: 8.5.15
       semver: 7.8.0
     optionalDependencies:
-      webpack: 5.106.2(esbuild@0.28.1)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
     transitivePeerDependencies:
       - typescript
 
@@ -9504,10 +9426,10 @@ snapshots:
     dependencies:
       fast-diff: 1.3.0
 
-  prettier-plugin-java@2.8.1(prettier@3.8.4):
+  prettier-plugin-java@2.9.7(prettier@3.8.4):
     dependencies:
-      java-parser: 3.0.1
       prettier: 3.8.4
+      web-tree-sitter: 0.26.9
 
   prettier-plugin-packagejson@3.0.2(prettier@3.8.4):
     dependencies:
@@ -9718,12 +9640,12 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.7(sass@1.99.0)(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15)):
+  sass-loader@16.0.7(sass@1.99.0)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
       sass: 1.99.0
-      webpack: 5.106.2(esbuild@0.28.1)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
 
   sass@1.101.0:
     dependencies:
@@ -9906,11 +9828,11 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15)):
+  source-map-loader@5.0.0(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
-      webpack: 5.106.2(esbuild@0.28.1)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
 
   source-map-support@0.5.21:
     dependencies:
@@ -10008,23 +9930,16 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
-  terser-webpack-plugin@5.6.0(esbuild@0.28.1)(postcss@8.5.15)(webpack@5.106.2(postcss@8.5.15)):
+  terser-webpack-plugin@5.6.0(esbuild@0.28.1)(postcss@8.5.15)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
-      terser: 5.46.0
-      webpack: 5.106.2(esbuild@0.28.1)(postcss@8.5.15)
+      terser: 5.46.2
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
     optionalDependencies:
       esbuild: 0.28.1
       postcss: 8.5.15
-
-  terser@5.46.0:
-    dependencies:
-      '@jridgewell/source-map': 0.3.11
-      acorn: 8.16.0
-      commander: 2.20.3
-      source-map-support: 0.5.21
 
   terser@5.46.2:
     dependencies:
@@ -10189,7 +10104,9 @@ snapshots:
   weak-lru-cache@1.2.2:
     optional: true
 
-  webpack-dev-middleware@8.0.3(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15)):
+  web-tree-sitter@0.26.9: {}
+
+  webpack-dev-middleware@8.0.3(tslib@2.8.1)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
       memfs: 4.57.2(tslib@2.8.1)
       mime-types: 3.0.2
@@ -10197,11 +10114,11 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.106.2(esbuild@0.28.1)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.3(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15)):
+  webpack-dev-server@5.2.5(tslib@2.8.1)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -10229,10 +10146,10 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 8.0.3(tslib@2.8.1)(webpack@5.106.2(postcss@8.5.15))
+      webpack-dev-middleware: 8.0.3(tslib@2.8.1)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
       ws: 8.21.0
     optionalDependencies:
-      webpack: 5.106.2(esbuild@0.28.1)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -10248,14 +10165,15 @@ snapshots:
 
   webpack-sources@3.4.1: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15)):
+  webpack-sources@3.5.0: {}
+
+  webpack-subresource-integrity@5.1.0(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
       typed-assert: 1.0.9
-      webpack: 5.106.2(esbuild@0.28.1)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
 
-  webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15):
+  webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15):
     dependencies:
-      '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
       '@webassemblyjs/ast': 1.14.1
@@ -10265,7 +10183,7 @@ snapshots:
       acorn-import-phases: 1.0.4(acorn@8.16.0)
       browserslist: 4.28.2
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.21.3
+      enhanced-resolve: 5.24.0
       es-module-lexer: 2.1.0
       eslint-scope: 5.1.1
       events: 3.3.0
@@ -10276,9 +10194,9 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(esbuild@0.28.1)(postcss@8.5.15)(webpack@5.106.2(postcss@8.5.15))
+      terser-webpack-plugin: 5.6.0(esbuild@0.28.1)(postcss@8.5.15)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
       watchpack: 2.5.1
-      webpack-sources: 3.4.1
+      webpack-sources: 3.5.0
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,9 +52,9 @@ overrides:
   punycode: 2.3.1
   rimraf: 6.1.3
   tough-cookie: 6.0.1
-  webpack: 5.106.2
+  webpack: 5.107.2
   webpack-dev-middleware: 8.0.3
-  webpack-dev-server: 5.2.3
+  webpack-dev-server: 5.2.5
   word-wrap: 1.2.5
   ws: 8.21.0
   yargs-parser: 22.0.0

--- a/run-e2e-tests-local-fast.sh
+++ b/run-e2e-tests-local-fast.sh
@@ -125,7 +125,7 @@ else
   docker rm -f "$MYSQL_CONTAINER" >/dev/null 2>&1 || true
   docker run -d --name "$MYSQL_CONTAINER" -p 127.0.0.1:3307:3306 \
     -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -e MYSQL_DATABASE=artemis-benchmarking \
-    mysql:9.7.0 mysqld --lower_case_table_names=1 --tls-version='' \
+    mysql:9.7.1 mysqld --lower_case_table_names=1 --tls-version='' \
     --character_set_server=utf8mb4 --explicit_defaults_for_timestamp >/dev/null
   elapsed=0
   until docker exec "$MYSQL_CONTAINER" mysqladmin ping -h 127.0.0.1 --silent >/dev/null 2>&1; do

--- a/src/main/docker/mysql.yml
+++ b/src/main/docker/mysql.yml
@@ -2,7 +2,7 @@
 name: artemis-benchmarking
 services:
   mysql:
-    image: mysql:9.7.0
+    image: mysql:9.7.1
     volumes:
       - ./config/mysql:/etc/mysql/conf.d
     environment:

--- a/src/main/java/de/tum/cit/aet/artemisModel/Participation.java
+++ b/src/main/java/de/tum/cit/aet/artemisModel/Participation.java
@@ -10,14 +10,12 @@ import java.util.Set;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 // Annotation necessary to distinguish between concrete implementations of Exercise when deserializing from JSON
-@JsonSubTypes(
-    {
-        @JsonSubTypes.Type(value = StudentParticipation.class, name = "student"),
-        @JsonSubTypes.Type(value = ProgrammingExerciseStudentParticipation.class, name = "programming"),
-        @JsonSubTypes.Type(value = TemplateProgrammingExerciseParticipation.class, name = "template"),
-        @JsonSubTypes.Type(value = SolutionProgrammingExerciseParticipation.class, name = "solution"),
-    }
-)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = StudentParticipation.class, name = "student"),
+    @JsonSubTypes.Type(value = ProgrammingExerciseStudentParticipation.class, name = "programming"),
+    @JsonSubTypes.Type(value = TemplateProgrammingExerciseParticipation.class, name = "template"),
+    @JsonSubTypes.Type(value = SolutionProgrammingExerciseParticipation.class, name = "solution"),
+})
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Participation extends DomainObject {
 

--- a/src/main/java/de/tum/cit/aet/config/GlobalExceptionHandler.java
+++ b/src/main/java/de/tum/cit/aet/config/GlobalExceptionHandler.java
@@ -31,12 +31,10 @@ public class GlobalExceptionHandler {
         return ResponseEntity.internalServerError().build();
     }
 
-    @ExceptionHandler(
-        {
-            org.springframework.http.converter.HttpMessageNotWritableException.class,
-            com.fasterxml.jackson.databind.exc.InvalidDefinitionException.class,
-        }
-    )
+    @ExceptionHandler({
+        org.springframework.http.converter.HttpMessageNotWritableException.class,
+        com.fasterxml.jackson.databind.exc.InvalidDefinitionException.class,
+    })
     public ResponseEntity<Object> handleSerialization(Exception ex, WebRequest req) {
         log.error("Serialization error: {}", ex.getMessage(), ex);
         return ResponseEntity.internalServerError().build();

--- a/src/main/java/de/tum/cit/aet/config/SecurityConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/config/SecurityConfiguration.java
@@ -58,8 +58,7 @@ public class SecurityConfiguration {
      */
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) {
-        http
-            .cors(withDefaults())
+        http.cors(withDefaults())
             .csrf(AbstractHttpConfigurer::disable)
             .addFilterAfter(new SpaWebFilter(), BasicAuthenticationFilter.class)
             .headers(headers ->

--- a/src/main/java/de/tum/cit/aet/service/MailService.java
+++ b/src/main/java/de/tum/cit/aet/service/MailService.java
@@ -159,14 +159,12 @@ public class MailService {
         context.setVariable("result", result);
         context.setVariable(BASE_URL, baseUrl);
         String subject = "Artemis-Benchmarking - Result for scheduled run";
-        schedule
-            .getSubscribers()
-            .forEach(subscriber -> {
-                context.setVariable("subscriber", subscriber);
-                String content = templateEngine.process("mail/subscriptionResultEmail", context);
-                log.debug("Sending run result email to '{}'", subscriber.getEmail());
-                self.sendEmail(subscriber.getEmail(), subject, content, false, true);
-            });
+        schedule.getSubscribers().forEach(subscriber -> {
+            context.setVariable("subscriber", subscriber);
+            String content = templateEngine.process("mail/subscriptionResultEmail", context);
+            log.debug("Sending run result email to '{}'", subscriber.getEmail());
+            self.sendEmail(subscriber.getEmail(), subject, content, false, true);
+        });
     }
 
     /**
@@ -194,13 +192,11 @@ public class MailService {
         }
         context.setVariable(BASE_URL, baseUrl);
         String subject = "Artemis-Benchmarking - Scheduled run failed";
-        schedule
-            .getSubscribers()
-            .forEach(subscriber -> {
-                context.setVariable("subscriber", subscriber);
-                String content = templateEngine.process("mail/subscriptionFailureEmail", context);
-                log.debug("Sending run failure result email to '{}'", subscriber.getEmail());
-                self.sendEmail(subscriber.getEmail(), subject, content, false, true);
-            });
+        schedule.getSubscribers().forEach(subscriber -> {
+            context.setVariable("subscriber", subscriber);
+            String content = templateEngine.process("mail/subscriptionFailureEmail", context);
+            log.debug("Sending run failure result email to '{}'", subscriber.getEmail());
+            self.sendEmail(subscriber.getEmail(), subject, content, false, true);
+        });
     }
 }

--- a/src/main/java/de/tum/cit/aet/service/UserService.java
+++ b/src/main/java/de/tum/cit/aet/service/UserService.java
@@ -60,16 +60,14 @@ public class UserService {
      */
     public Optional<User> activateRegistration(String key) {
         log.debug("Activating user for activation key {}", key);
-        return userRepository
-            .findOneByActivationKey(key)
-            .map(user -> {
-                // activate given user for the registration key.
-                user.setActivated(true);
-                user.setActivationKey(null);
-                this.clearUserCaches(user);
-                log.debug("Activated user: {}", user);
-                return user;
-            });
+        return userRepository.findOneByActivationKey(key).map(user -> {
+            // activate given user for the registration key.
+            user.setActivated(true);
+            user.setActivationKey(null);
+            this.clearUserCaches(user);
+            log.debug("Activated user: {}", user);
+            return user;
+        });
     }
 
     /**
@@ -196,13 +194,11 @@ public class UserService {
      * @param login the login of the user to delete.
      */
     public void deleteUser(String login) {
-        userRepository
-            .findOneByLogin(login)
-            .ifPresent(user -> {
-                userRepository.delete(user);
-                this.clearUserCaches(user);
-                log.debug("Deleted User: {}", user);
-            });
+        userRepository.findOneByLogin(login).ifPresent(user -> {
+            userRepository.delete(user);
+            this.clearUserCaches(user);
+            log.debug("Deleted User: {}", user);
+        });
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/service/artemis/interaction/SimulatedArtemisStudent.java
+++ b/src/main/java/de/tum/cit/aet/service/artemis/interaction/SimulatedArtemisStudent.java
@@ -788,8 +788,7 @@ public class SimulatedArtemisStudent extends SimulatedArtemisUser {
             case ONLINE_IDE -> throw new IllegalStateException("Cannot push to Online IDE via jgit");
             case PASSWORD -> git.push().setCredentialsProvider(getCredentialsProvider()).call();
             case PARTICIPATION_TOKEN -> git.push().setCredentialsProvider(getCredentialsProviderWithToken()).call();
-            case SSH -> git
-                .push()
+            case SSH -> git.push()
                 .setTransportConfigCallback(transport -> {
                     SshTransport sshTransport = (SshTransport) transport;
                     sshTransport.setSshSessionFactory(getSessionFactory(keyPair));
@@ -894,7 +893,12 @@ public class SimulatedArtemisStudent extends SimulatedArtemisUser {
 
     private RequestStat fetchRepository(Long participationId) {
         long start = System.nanoTime();
-        webClient.get().uri("api/programming/repository/" + participationId).retrieve().toBodilessEntity().block();
+        webClient
+            .get()
+            .uri("api/programming/repository/" + participationId)
+            .retrieve()
+            .toBodilessEntity()
+            .block();
         return new RequestStat(now(), System.nanoTime() - start, REPOSITORY_INFO);
     }
 
@@ -912,7 +916,12 @@ public class SimulatedArtemisStudent extends SimulatedArtemisUser {
 
     private RequestStat fetchFiles(Long participationId) {
         long start = System.nanoTime();
-        webClient.get().uri("api/programming/repository/" + participationId + "/files").retrieve().toBodilessEntity().block();
+        webClient
+            .get()
+            .uri("api/programming/repository/" + participationId + "/files")
+            .retrieve()
+            .toBodilessEntity()
+            .block();
         return new RequestStat(now(), System.nanoTime() - start, REPOSITORY_FILES);
     }
 
@@ -920,7 +929,12 @@ public class SimulatedArtemisStudent extends SimulatedArtemisUser {
         long start = System.nanoTime();
         String plantUmlString =
             "%40startuml%0A%0Aclass%20Client%20%7B%0A%7D%0A%0Aclass%20Policy%20%7B%0A%20%20%3Ccolor%3Agrey%3E%2Bconfigure()%3C%2Fcolor%3E%0A%7D%0A%0Aclass%20Context%20%7B%0A%20%20%3Ccolor%3Agrey%3E-dates%3A%20List%3CDate%3E%3C%2Fcolor%3E%0A%20%20%3Ccolor%3Agrey%3E%2Bsort()%3C%2Fcolor%3E%0A%7D%0A%0Ainterface%20SortStrategy%20%7B%0A%20%20%3Ccolor%3Agrey%3E%2BperformSort(List%3CDate%3E)%3C%2Fcolor%3E%0A%7D%0A%0Aclass%20BubbleSort%20%7B%0A%20%20%3Ccolor%3Agrey%3E%2BperformSort(List%3CDate%3E)%3C%2Fcolor%3E%0A%7D%0A%0Aclass%20MergeSort%20%7B%0A%20%20%3Ccolor%3Agrey%3E%2BperformSort(List%3CDate%3E)%3C%2Fcolor%3E%0A%7D%0A%0AMergeSort%20-up-%7C%3E%20SortStrategy%20%23grey%0ABubbleSort%20-up-%7C%3E%20SortStrategy%20%23grey%0APolicy%20-right-%3E%20Context%20%23grey%3A%20context%0AContext%20-right-%3E%20SortStrategy%20%23grey%3A%20sortAlgorithm%0AClient%20.down.%3E%20Policy%0AClient%20.down.%3E%20Context%0A%0Ahide%20empty%20fields%0Ahide%20empty%20methods%0A%0A%40enduml&useDarkTheme=true";
-        webClient.get().uri("api/programming/plantuml/svg?plantuml=" + plantUmlString).retrieve().toBodilessEntity().block();
+        webClient
+            .get()
+            .uri("api/programming/plantuml/svg?plantuml=" + plantUmlString)
+            .retrieve()
+            .toBodilessEntity()
+            .block();
         return new RequestStat(now(), System.nanoTime() - start, MISC);
     }
 
@@ -1102,7 +1116,10 @@ public class SimulatedArtemisStudent extends SimulatedArtemisUser {
     }
 
     private String getSshCloneUrl(String cloneUrl) {
-        var artemisServerHostname = artemisUrl.substring(artemisUrl.indexOf("//") + 2).split("/")[0].split(":")[0];
+        var artemisServerHostname = artemisUrl
+            .substring(artemisUrl.indexOf("//") + 2)
+            .split("/")[0]
+            .split(":")[0];
         return "ssh://git@" + artemisServerHostname + ":7921" + cloneUrl.substring(cloneUrl.indexOf("/git/"));
     }
 

--- a/src/main/java/de/tum/cit/aet/service/artemis/interaction/SimulatedArtemisUser.java
+++ b/src/main/java/de/tum/cit/aet/service/artemis/interaction/SimulatedArtemisUser.java
@@ -252,8 +252,7 @@ public abstract class SimulatedArtemisUser {
             .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 30 * 1000)
             .secure(spec -> {
                 try {
-                    spec
-                        .sslContext(TcpSslContextSpec.forClient().sslContext())
+                    spec.sslContext(TcpSslContextSpec.forClient().sslContext())
                         .handshakeTimeout(Duration.ofSeconds(30))
                         .closeNotifyFlushTimeout(Duration.ofSeconds(30))
                         .closeNotifyReadTimeout(Duration.ofSeconds(30));

--- a/src/main/java/de/tum/cit/aet/service/simulation/SimulationDataService.java
+++ b/src/main/java/de/tum/cit/aet/service/simulation/SimulationDataService.java
@@ -241,7 +241,7 @@ public class SimulationDataService {
             switch (simulation.getMode()) {
                 case CREATE_COURSE_AND_EXAM -> true;
                 case EXISTING_COURSE_UNPREPARED_EXAM, EXISTING_COURSE_PREPARED_EXAM -> simulation.getCourseId() > 0 &&
-                simulation.getExamId() > 0;
+                    simulation.getExamId() > 0;
                 case EXISTING_COURSE_CREATE_EXAM -> simulation.getCourseId() > 0;
             }
         );

--- a/src/main/java/de/tum/cit/aet/util/LinkHeaderUtil.java
+++ b/src/main/java/de/tum/cit/aet/util/LinkHeaderUtil.java
@@ -25,8 +25,7 @@ public class LinkHeaderUtil {
         if (pageNumber > 0) {
             link.append(prepareLink(uriBuilder, pageNumber - 1, pageSize, "prev")).append(",");
         }
-        link
-            .append(prepareLink(uriBuilder, page.getTotalPages() - 1, pageSize, "last"))
+        link.append(prepareLink(uriBuilder, page.getTotalPages() - 1, pageSize, "last"))
             .append(",")
             .append(prepareLink(uriBuilder, 0, pageSize, "first"));
         return link.toString();

--- a/src/test/java/de/tum/cit/aet/security/jwt/TokenAuthenticationIT.java
+++ b/src/test/java/de/tum/cit/aet/security/jwt/TokenAuthenticationIT.java
@@ -46,8 +46,8 @@ class TokenAuthenticationIT {
     }
 
     private void expectUnauthorized(String token) throws Exception {
-        mvc
-            .perform(MockMvcRequestBuilders.get("/api/authenticate").header(AUTHORIZATION, BEARER + token))
-            .andExpect(status().isUnauthorized());
+        mvc.perform(MockMvcRequestBuilders.get("/api/authenticate").header(AUTHORIZATION, BEARER + token)).andExpect(
+            status().isUnauthorized()
+        );
     }
 }

--- a/src/test/java/de/tum/cit/aet/service/SimulationExecutionServiceIT.java
+++ b/src/test/java/de/tum/cit/aet/service/SimulationExecutionServiceIT.java
@@ -209,10 +209,11 @@ public class SimulationExecutionServiceIT {
         verify(simulatedArtemisAdmin, times(0)).getCourse(anyLong());
         verify(simulatedArtemisAdmin, times(1)).createExam(course);
         verify(simulatedArtemisAdmin, times(1)).createExamExercises(1, exam);
-        verify(simulatedArtemisAdmin, times(1)).registerStudentsForCourse(
-            1,
-            new SimulatedArtemisStudent[] { simulatedArtemisStudent1, simulatedArtemisStudent2, simulatedArtemisStudent3 }
-        );
+        verify(simulatedArtemisAdmin, times(1)).registerStudentsForCourse(1, new SimulatedArtemisStudent[] {
+            simulatedArtemisStudent1,
+            simulatedArtemisStudent2,
+            simulatedArtemisStudent3,
+        });
         verify(simulatedArtemisAdmin, times(1)).registerStudentsForExam(1, 1);
         verify(simulatedArtemisAdmin, times(1)).prepareExam(1, 1);
 
@@ -281,10 +282,11 @@ public class SimulationExecutionServiceIT {
         verify(simulatedArtemisAdmin, times(0)).getCourse(anyLong());
         verify(simulatedArtemisAdmin, times(1)).createExam(course);
         verify(simulatedArtemisAdmin, times(1)).createExamExercises(1, exam);
-        verify(simulatedArtemisAdmin, times(1)).registerStudentsForCourse(
-            1,
-            new SimulatedArtemisStudent[] { simulatedArtemisStudent1, simulatedArtemisStudent2, simulatedArtemisStudent3 }
-        );
+        verify(simulatedArtemisAdmin, times(1)).registerStudentsForCourse(1, new SimulatedArtemisStudent[] {
+            simulatedArtemisStudent1,
+            simulatedArtemisStudent2,
+            simulatedArtemisStudent3,
+        });
         verify(simulatedArtemisAdmin, times(1)).registerStudentsForExam(1, 1);
         verify(simulatedArtemisAdmin, times(1)).prepareExam(1, 1);
         verify(simulatedArtemisAdmin, timeout(1000).times(0)).deleteCourse(anyLong());
@@ -627,10 +629,11 @@ public class SimulationExecutionServiceIT {
         verify(simulatedArtemisAdmin, times(0)).getCourse(anyLong());
         verify(simulatedArtemisAdmin, times(1)).createExam(course);
         verify(simulatedArtemisAdmin, times(1)).createExamExercises(1, exam);
-        verify(simulatedArtemisAdmin, times(1)).registerStudentsForCourse(
-            1,
-            new SimulatedArtemisStudent[] { simulatedArtemisStudent1, simulatedArtemisStudent2, simulatedArtemisStudent3 }
-        );
+        verify(simulatedArtemisAdmin, times(1)).registerStudentsForCourse(1, new SimulatedArtemisStudent[] {
+            simulatedArtemisStudent1,
+            simulatedArtemisStudent2,
+            simulatedArtemisStudent3,
+        });
         verify(simulatedArtemisAdmin, times(1)).registerStudentsForExam(1, 1);
         verify(simulatedArtemisAdmin, times(1)).prepareExam(1, 1);
         verify(simulatedArtemisAdmin, timeout(1000).times(1)).deleteCourse(1);
@@ -888,10 +891,11 @@ public class SimulationExecutionServiceIT {
         verify(simulatedArtemisAdmin, times(0)).getCourse(anyLong());
         verify(simulatedArtemisAdmin, times(0)).createExam(any());
         verify(simulatedArtemisAdmin, times(0)).createExamExercises(anyLong(), any());
-        verify(simulatedArtemisAdmin, times(1)).registerStudentsForCourse(
-            1,
-            new SimulatedArtemisStudent[] { simulatedArtemisStudent1, simulatedArtemisStudent2, simulatedArtemisStudent3 }
-        );
+        verify(simulatedArtemisAdmin, times(1)).registerStudentsForCourse(1, new SimulatedArtemisStudent[] {
+            simulatedArtemisStudent1,
+            simulatedArtemisStudent2,
+            simulatedArtemisStudent3,
+        });
         verify(simulatedArtemisAdmin, times(0)).registerStudentsForExam(anyLong(), anyLong());
         verify(simulatedArtemisAdmin, times(0)).prepareExam(anyLong(), anyLong());
         verify(simulatedArtemisAdmin, timeout(1000).times(1)).deleteCourse(1);

--- a/src/test/java/de/tum/cit/aet/service/artemis/interaction/SimulatedArtemisAdminTest.java
+++ b/src/test/java/de/tum/cit/aet/service/artemis/interaction/SimulatedArtemisAdminTest.java
@@ -191,20 +191,18 @@ class SimulatedArtemisAdminTest {
     }
 
     private static Mono<String> extractMultipartPart(ServerRequest request, String partName) {
-        return request
-            .body(BodyExtractors.toMultipartData())
-            .flatMap(parts -> {
-                Part part = parts.getFirst(partName);
-                if (part == null) {
-                    return Mono.just("");
-                }
-                return DataBufferUtils.join(part.content()).map(buffer -> {
-                    byte[] bytes = new byte[buffer.readableByteCount()];
-                    buffer.read(bytes);
-                    DataBufferUtils.release(buffer);
-                    return new String(bytes, StandardCharsets.UTF_8);
-                });
+        return request.body(BodyExtractors.toMultipartData()).flatMap(parts -> {
+            Part part = parts.getFirst(partName);
+            if (part == null) {
+                return Mono.just("");
+            }
+            return DataBufferUtils.join(part.content()).map(buffer -> {
+                byte[] bytes = new byte[buffer.readableByteCount()];
+                buffer.read(bytes);
+                DataBufferUtils.release(buffer);
+                return new String(bytes, StandardCharsets.UTF_8);
             });
+        });
     }
 
     private static CapturedRequest findRequest(Queue<CapturedRequest> captured, String path) {


### PR DESCRIPTION
## Summary

- **`prettier-plugin-java` 2.8.1 → 2.9.7** and reformat the 12 Java files the new version formats differently. Changes are cosmetic (e.g. method-chain wrapping); `pnpm run prettier:check` (which covers `.java`) now passes. Supersedes #788.
- **`webpack` 5.106.2 → 5.107.2** and **`webpack-dev-server` 5.2.3 → 5.2.5** (`pnpm-workspace.yaml` overrides). Supersedes #791 and #766.
- **MySQL Docker image `9.7.0` → `9.7.1`** in `docker-compose.yml`, `src/main/docker/mysql.yml`, and the fast e2e runner. Supersedes #790.

Client `ncu --target minor` and the server `dependencyUpdates` report show no other non-breaking updates available.

## ⚠️ modernizer 1.15.0 not applied
The request to bump `modernizerPluginVersion` to **1.15.0** could not be honored: that version is **not published** — the latest `com.github.andygoossens.gradle-modernizer-plugin` on the Gradle Plugin Portal is **1.14.0** (already in use), and the `dependencyUpdates` report confirms no newer release. Left at 1.14.0.

## Testing
- `pnpm run prettier:check` ✅ · `pnpm run lint` ✅ · `pnpm run webapp:build` ✅
- `pnpm install --frozen-lockfile` ✅
- `./gradlew compileJava compileTestJava modernizer spotlessCheck test -x webapp` ✅ (29 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)