### PR TITLE
Align build node to 24.16.0 and bump upload-artifact to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: playwright-report/

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ rootProject.name=artemis-benchmarking
 profile=dev
 
 # Build properties
-node_version=24.15.0
+node_version=24.16.0
 pnpm_version=11.7.0
 
 # Dependency versions


### PR DESCRIPTION
## Summary

Two build-config dependency updates that were not covered by Renovate / the recent dependency PRs:

- **`gradle.properties` `node_version` 24.15.0 → 24.16.0** — CI already runs Node 24.16.0 (after #787) and that is the latest 24.x, but the Gradle node plugin (used for the client build and the production Docker image) still pinned 24.15.0. Renovate doesn't manage this custom property, so it slipped through. Verified: `./gradlew -Pprod webapp` builds successfully on 24.16.0.
- **`actions/upload-artifact` v4 → v7** in the e2e CI job (the only outdated GitHub Action). Covers #794.

## Audit (nothing else outstanding)
A full sweep confirmed everything else is current:
- **Client**: `ncu` reports all `package.json` deps at latest.
- **Server / Gradle plugins**: `dependencyUpdates` shows no stable updates (only Gradle 9.6.0-rc, intentionally rejected as non-stable).
- **Docker images**: mysql 9.7.1, azul/zulu-openjdk 25.0.3, nginx 1.31.1 are all the latest in their lines.
- **Other GitHub Actions**: checkout@v6, setup-java@v5, setup-node@v6, pnpm/action-setup@v6, github-script@v9, docker/* — all current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)