### PR TITLE
Fix: package the Angular web app into the prod WAR

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -22,7 +22,7 @@
           "options": {
             "allowedCommonJsDependencies": ["rfdc", "@stomp/rx-stomp", "@stomp/stompjs"],
             "outputPath": {
-              "base": "build/resources/main/static/",
+              "base": "build/webapp",
               "browser": ""
             },
             "index": "src/main/webapp/index.html",

--- a/gradle/profile_dev.gradle
+++ b/gradle/profile_dev.gradle
@@ -34,7 +34,9 @@ tasks.register("webapp", PnpmTask) {
     inputs.dir("src/main/webapp/")
         .withPropertyName("webapp-source-dir")
         .withPathSensitivity(PathSensitivity.RELATIVE)
-    outputs.dir("build/resources/main/static/")
+    // Build into a dedicated directory so it never overlaps with processResources' output
+    // dir (build/resources/main); otherwise the static webapp is wiped on clean CI builds.
+    outputs.dir("build/webapp")
         .withPropertyName("webapp-build-dir")
 
     dependsOn pnpmInstall
@@ -44,6 +46,11 @@ tasks.register("webapp", PnpmTask) {
 }
 
 processResources {
+    dependsOn webapp
+    // Copy the compiled webapp in as a Spring Boot static resource.
+    from("build/webapp") {
+        into "static"
+    }
     inputs.property("version", version)
     inputs.property("springProfiles", springProfiles)
     filesMatching("**/application.yml") {
@@ -56,5 +63,4 @@ processResources {
     }
 }
 
-processResources.dependsOn webapp
 bootJar.dependsOn processResources

--- a/gradle/profile_prod.gradle
+++ b/gradle/profile_prod.gradle
@@ -21,11 +21,26 @@ bootRun {
 
 tasks.register("webapp", PnpmTask) {
     dependsOn pnpmInstall
+    inputs.dir("src/main/webapp/")
+        .withPropertyName("webapp-source-dir")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.files("pnpm-lock.yaml", "angular.json", "tsconfig.json", "tsconfig.app.json")
+        .withPropertyName("webapp-config")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+    // Build into a dedicated directory so it never overlaps with processResources' output
+    // dir (build/resources/main); otherwise the static webapp is wiped on clean CI builds.
+    outputs.dir("build/webapp")
+        .withPropertyName("webapp-build-dir")
     args = ["run", "webapp:prod"]
     environment = [APP_VERSION: project.version]
 }
 
 processResources {
+    dependsOn webapp
+    // Copy the compiled webapp in as a Spring Boot static resource.
+    from("build/webapp") {
+        into "static"
+    }
     inputs.property("version", version)
     inputs.property("springProfiles", springProfiles)
     filesMatching("**/application.yml") {
@@ -38,5 +53,4 @@ processResources {
     }
 }
 
-processResources.dependsOn webapp
 bootJar.dependsOn processResources

--- a/gradle/war.gradle
+++ b/gradle/war.gradle
@@ -9,10 +9,24 @@ bootWar {
                    "Implementation-Version": version)
     }
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+
+    // Guard against shipping a WAR without the Angular webapp (see the webapp/processResources
+    // wiring in profile_*.gradle). Fails the build loudly instead of deploying a broken artifact.
+    doLast {
+        def archive = archiveFile.get().asFile
+        def hasIndex = new java.util.zip.ZipFile(archive).withCloseable { zip ->
+            zip.entries().any { it.name.endsWith("static/index.html") }
+        }
+        if (!hasIndex) {
+            throw new GradleException("Webapp missing from ${archive.name}: no '**/static/index.html' " +
+                "entry found. The Angular build was not packaged into the WAR — refusing to produce a broken artifact.")
+        }
+        logger.lifecycle("Verified the Angular webapp is packaged in ${archive.name}")
+    }
 }
 
 war {
-    webAppDirectory = file("build/resources/main/static/")
+    webAppDirectory = file("build/webapp")
     includes = ["WEB-INF/**", "META-INF/**"]
     webXml = file("${project.rootDir}/src/main/webapp/WEB-INF/web.xml")
     enabled = true


### PR DESCRIPTION
## Problem
The deployed prod app returned `404 "No static resource index.html"` at `/` — the Angular webapp was missing from the WAR (0 `static/` entries), even though the API worked.

## Root cause
The `webapp` task built the webapp into `build/resources/main/static`, **inside** `processResources`'s output directory. On a clean checkout (CI/Docker, no warm Gradle history), Gradle 9.6's overlapping-output handling makes `processResources` **wipe** the `static/` subdir. It only worked locally due to warm build history. Latent issue exposed by the Gradle 9.6 upgrade (#805); the prod `webapp` task also never declared `outputs.dir`, so Gradle didn't know it produced `static/`.

## Fix
- Build the Angular app into a dedicated **`build/webapp`** directory (no overlap), then have `processResources` copy it into `static/`. Applied to **both** dev and prod profiles, with proper `inputs`/`outputs` for caching.
- **Guard:** `bootWar` now fails the build if the produced WAR lacks `**/static/index.html` — a WAR without the webapp can never be deployed silently again.

## Verification
- Reproduced the failure in a clean **container** build (0 static entries), then confirmed the fix in the **same** build: **68 static entries**, `WEB-INF/classes/static/index.html` present, guard logs "Verified the Angular webapp is packaged", BUILD SUCCESSFUL.
- Guard **failure path** tested: skipping the webapp build now fails with `Webapp missing from … refusing to produce a broken artifact`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)