### PR TITLE
Fix: simulations 500 on PostgreSQL (mixed-case column) + portability guard

### DIFF
--- a/src/main/resources/config/liquibase/changelog/20260620120000_fix_onlineide_percentage_case.xml
+++ b/src/main/resources/config/liquibase/changelog/20260620120000_fix_onlineide_percentage_case.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!--
+      The `simulation` table column was originally created as `onlineIde_percentage` (mixed case).
+      This was harmless on case-insensitive MySQL, but on PostgreSQL Liquibase quotes mixed-case
+      identifiers, so the column did not match the entity's lowercase mapping
+      (Simulation.onlineIdePercentage -> "onlineide_percentage"). As a result Hibernate's
+      `select ... onlineide_percentage ... from simulation` failed with
+      "column onlineide_percentage does not exist", breaking `GET /api/simulations`.
+
+      Rename the column to lowercase so it matches the entity on PostgreSQL. The precondition
+      makes this idempotent: it only runs where the mixed-case column still exists (fresh installs
+      and not-yet-migrated environments), and is marked as ran elsewhere.
+    -->
+    <changeSet id="20260620120000-fix-onlineide-percentage-case" author="benchmarking">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">
+                SELECT count(*) FROM information_schema.columns
+                WHERE table_name = 'simulation' AND column_name = 'onlineIde_percentage'
+            </sqlCheck>
+        </preConditions>
+        <renameColumn tableName="simulation"
+                      oldColumnName="onlineIde_percentage"
+                      newColumnName="onlineide_percentage"
+                      columnDataType="double"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -4,4 +4,5 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
     <include file="config/liquibase/changelog/00000000000000_initial_schema.xml" relativeToChangelogFile="false"/>
+    <include file="config/liquibase/changelog/20260620120000_fix_onlineide_percentage_case.xml" relativeToChangelogFile="false"/>
 </databaseChangeLog>

--- a/src/test/java/de/tum/cit/aet/SchemaPortabilityIT.java
+++ b/src/test/java/de/tum/cit/aet/SchemaPortabilityIT.java
@@ -1,0 +1,38 @@
+package de.tum.cit.aet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Guards against MySQL -> PostgreSQL portability regressions in the Liquibase schema.
+ *
+ * <p>On PostgreSQL, Liquibase quotes mixed-case identifiers, so a column declared as e.g.
+ * {@code onlineIde_percentage} is created case-sensitively and no longer matches Hibernate's
+ * case-folded (lowercase) column name. This surfaces only at runtime as
+ * "column ... does not exist". Keeping all column names lowercase avoids the whole class of bug.
+ */
+@IntegrationTest
+class SchemaPortabilityIT {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void allColumnNamesAreLowercase() {
+        List<String> mixedCaseColumns = jdbcTemplate.queryForList(
+            "SELECT table_name || '.' || column_name FROM information_schema.columns " +
+                "WHERE table_schema = 'public' AND column_name <> lower(column_name) ORDER BY 1",
+            String.class
+        );
+        assertThat(mixedCaseColumns)
+            .as(
+                "mixed-case column names are not portable to PostgreSQL (Liquibase quotes them while " +
+                    "Hibernate folds to lowercase); rename them to lowercase in the Liquibase changelog"
+            )
+            .isEmpty();
+    }
+}


### PR DESCRIPTION
## Problem
`GET /api/simulations` returns **500** on the deployed (PostgreSQL) app, so the simulations list shows empty.

```
ERROR: column s1_0.onlineide_percentage does not exist
```

## Root cause
The `simulation` table column was declared as `onlineIde_percentage` (mixed case) in the Liquibase changelog. On PostgreSQL, Liquibase **quotes** mixed-case identifiers, so the column is created case-sensitively and no longer matches the entity's lowercase mapping (`Simulation.onlineIdePercentage` → `onlineide_percentage`). Hibernate's case-folded query can't find it. This was harmless on case-insensitive MySQL — exposed by the MySQL→PostgreSQL switch.

Only **one** column was affected (verified against the schema).

## Fix
- **Idempotent Liquibase changeset** renaming `onlineIde_percentage` → `onlineide_percentage`. A precondition (`MARK_RAN`) means it only runs where the mixed-case column still exists, so it's safe on environments already corrected and on fresh installs.
- **`SchemaPortabilityIT`** — fails the build if *any* `public` column name isn't lowercase, preventing this whole class of MySQL→PostgreSQL portability bug from recurring.

## Verification
- Targeted `integrationTest` (guard + existing `SimulationDataServiceIT`): **29/29 pass**.
- **Negative test** (changeset disabled): `SchemaPortabilityIT` fails with `Expecting empty but was: ["simulation.onlineIde_percentage"]` — the guard catches the exact bug.
- Prod was already hot-fixed with the equivalent `ALTER TABLE … RENAME COLUMN` (metadata-only) to restore service immediately; this PR makes the fix permanent and covers fresh installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)